### PR TITLE
Add --version/-V flag to display whoosh version (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project are documented here. This project follows
 
 ### Added
 
+- **`whoosh --version` / `whoosh -V` flag.** The CLI now has a top-level
+  `--version` / `-V` flag to display the current version and exit immediately,
+  before any subcommand parsing. The version string comes from the single
+  source of truth `whoosh.__version_str__`, so it never drifts from the
+  package version. Handy for bug reports, CI, and packaging scripts.
+  Thanks to [@abu-pixel](https://github.com/abu-pixel) for the contribution
+  (#6).
+
 - **`whoosh search` match summary.** In the default text output mode, `whoosh
   search` now prints a short summary line to **stderr** — `N matches.` when
   everything is shown, or `Showing X of Y matches.` when results are truncated

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -30,6 +30,23 @@ and the installed console command is ``whoosh``::
     usage: whoosh [-h] {index,search} ...
 
 
+Check the version
+=================
+
+Display the current version of whoosh::
+
+    $ whoosh --version
+    whoosh 3.5.0
+
+    $ whoosh -V
+    whoosh 3.5.0
+
+The version string comes from the single source of truth
+``whoosh.__version_str__``, so it never drifts from the package version.
+This is useful for bug reports, CI pipelines, packaging scripts, and
+quickly confirming which version you are using.
+
+
 Index a folder
 ==============
 

--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -272,10 +272,20 @@ def _check_positive_int(value: str) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    from whoosh import __version_str__
+    
     p = argparse.ArgumentParser(
         prog="whoosh",
         description="Full-text search a folder of files, powered by Whoosh "
                     "(pure-Python, no server).")
+    
+    # Add version flag before subparsers
+    p.add_argument(
+        "-V", "--version",
+        action="version",
+        version=f"%(prog)s {__version_str__}",
+    )
+    
     sub = p.add_subparsers(dest="command", required=True)
 
     pi = sub.add_parser("index", help="build/refresh the search index")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-from whoosh import cli
+from whoosh import cli, __version_str__
 
 
 @pytest.fixture()
@@ -31,6 +31,28 @@ def corpus(tmp_path):
 
 def run(argv):
     return cli.main([str(a) for a in argv])
+
+
+def test_version_flag(capsys):
+    """Test that --version displays the version and exits with code 0."""
+    with pytest.raises(SystemExit) as excinfo:
+        run(["--version"])
+    
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert "whoosh" in captured.out
+    assert __version_str__ in captured.out
+
+
+def test_version_short_flag(capsys):
+    """Test that -V displays the version and exits with code 0."""
+    with pytest.raises(SystemExit) as excinfo:
+        run(["-V"])
+    
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert "whoosh" in captured.out
+    assert __version_str__ in captured.out
 
 
 def test_index_then_search(corpus, capsys):
@@ -129,7 +151,6 @@ def test_search_mutually_exclusive_json_html(corpus, capsys):
     assert "not allowed with argument" in err.lower()
 
 
-
 def test_search_limit_invalid(corpus, capsys):
     with pytest.raises(SystemExit):
         run(["search", "search", corpus, "--limit", "0"])
@@ -179,6 +200,7 @@ def test_search_fields_text(corpus, capsys):
     assert "path:" in out
     assert "score" not in out
 
+
 def test_search_count(corpus, capsys):
     assert run(["index", corpus]) == 0
     capsys.readouterr()
@@ -219,6 +241,7 @@ def test_search_summary_all_shown(corpus, capsys):
     assert "Showing" not in err
     assert "matches for" in out
     assert "match." not in out
+
 
 def test_search_summary_truncated(corpus, capsys):
     assert run(["index", corpus]) == 0


### PR DESCRIPTION
## Summary
Adds `--version` and `-V` flags to the whoosh CLI to display the current version.

## Changes
- Added `-V/--version` flag to `build_parser()` in `src/whoosh/cli.py`
- Uses `whoosh.__version_str__` as single source of truth
- Added tests for both flags in `tests/test_cli.py`
- Updated CLI documentation in `docs/source/cli.rst`
- Updated CHANGELOG.md

## Testing
- ✅ `whoosh --version` displays version and exits 0
- ✅ `whoosh -V` displays version and exits 0
- ✅ All existing tests pass

Closes #6