### PR TITLE
feat: add whoosh index --exclude PATTERN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project are documented here. This project follows
 
 ### Added
 
+- **`whoosh index --exclude`.** The CLI now supports excluding specific files or
+  directories during indexing using the `--exclude` flag with glob patterns
+  (e.g., `--exclude "build/*"`). It can be specified multiple times.
+
 - **`whoosh --version` / `-V`.** The CLI now has a top-level `--version` (and
   short `-V`) flag that prints the installed Whoosh version and exits. Thanks
   to [@abhiramvsmg](https://github.com/abhiramvsmg) for the contribution

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -52,6 +52,10 @@ are picked up with ``--ext`` (comma-separated)::
 
     $ whoosh index ~/notes --ext .md,.txt,.rst
 
+You can exclude specific folders or files using `--exclude` with glob patterns. This can be specified multiple times::
+
+    $ whoosh index ~/notes --exclude "build/*" --exclude "*.min.js"
+
 Re-index incrementally with ``--update``. Only files whose modification time
 changed are re-read, and files that were deleted are dropped from the index —
 so keeping a large tree fresh is cheap::

--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -33,8 +33,7 @@ import time
 from pathlib import PurePath
 from typing import TYPE_CHECKING
 
-from whoosh import __version_str__
-from whoosh import index
+from whoosh import __version_str__, index
 from whoosh.analysis import StemmingAnalyzer
 from whoosh.fields import ID, NUMERIC, TEXT, Schema
 from whoosh.highlight import ContextFragmenter, HtmlFormatter, UppercaseFormatter
@@ -238,7 +237,7 @@ def cmd_search(args: argparse.Namespace) -> int:
                 return 1
             print(f"No matches for: {args.query!r}")
             return 1
-            
+
         if getattr(args, "json", False):
             json_results = []
             for i, hit in enumerate(results, 1):
@@ -248,7 +247,7 @@ def cmd_search(args: argparse.Namespace) -> int:
                     snippet = hit.highlights("body") or (hit["body"][:160] + "...")
                     snippet = " ".join(snippet.split())
                     hit_dict = {
-                        "path": hit['path'],
+                        "path": hit["path"],
                         "score": hit.score,
                         "snippet": snippet
                     }
@@ -270,7 +269,7 @@ def cmd_search(args: argparse.Namespace) -> int:
                 snippet = " ".join(snippet.split())  # collapse whitespace
                 print(f"{i}. {hit['path']}  (score {hit.score:.2f})")
                 print(f"   {snippet}\n")
-        
+
         if getattr(args, "count", False) or getattr(args, "json", False) or getattr(args, "html", False):
             pass
         else:
@@ -324,7 +323,7 @@ def build_parser() -> argparse.ArgumentParser:
                     help="max results (default: 10)")
     ps.add_argument("--fields",
                     help="comma-separated list of stored fields to include in output")
-    
+
     group = ps.add_mutually_exclusive_group()
     group.add_argument("--html", action="store_true",
                     help="emit <mark>...</mark> HTML highlights instead of "

--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -17,6 +17,9 @@ pure Python::
     # Limit which files get indexed
     whoosh index ~/notes --ext .md,.txt,.rst
 
+    # Exclude specific files and directories
+    whoosh index . --exclude "build/*" --exclude "*.min.js"
+
 Everything here uses only the public Whoosh API, so the same code doubles as
 a worked example you can copy into your own project and adapt.
 """
@@ -27,6 +30,7 @@ import json
 import os
 import sys
 import time
+from pathlib import PurePath
 from typing import TYPE_CHECKING
 
 from whoosh import __version_str__
@@ -62,18 +66,30 @@ def build_schema() -> Schema:
     )
 
 
-def iter_files(root: str, exts: tuple[str, ...]):
+def iter_files(root: str, exts: tuple[str, ...], exclude: tuple[str, ...] = ()):
     """Yield ``(abspath, mtime)`` for files under *root* matching *exts*.
 
     Skips the index directory itself and common noise directories.
     """
     skip = {INDEX_DIRNAME, ".git", ".hg", "__pycache__", "node_modules", ".venv"}
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [d for d in dirnames if d not in skip]
+        new_dirnames = []
+        for d in dirnames:
+            if d in skip:
+                continue
+            rel_d = os.path.relpath(os.path.join(dirpath, d), root)
+            if any(PurePath(rel_d).match(pat) for pat in exclude):
+                continue
+            new_dirnames.append(d)
+        dirnames[:] = new_dirnames
+
         for name in filenames:
             if exts and not name.lower().endswith(exts):
                 continue
             full = os.path.join(dirpath, name)
+            rel_f = os.path.relpath(full, root)
+            if any(PurePath(rel_f).match(pat) for pat in exclude):
+                continue
             try:
                 yield full, os.path.getmtime(full)
             except OSError:
@@ -136,7 +152,7 @@ def cmd_index(args: argparse.Namespace) -> int:
     t0 = time.time()
     writer = ix.writer()
     try:
-        for full, mtime in iter_files(root, exts):
+        for full, mtime in iter_files(root, exts, exclude=tuple(args.exclude)):
             rel = os.path.relpath(full, root)
             seen.add(rel)
             if args.update and rel in indexed and indexed[rel] >= mtime:
@@ -293,6 +309,9 @@ def build_parser() -> argparse.ArgumentParser:
     pi.add_argument("--ext", default="",
                     help="comma-separated extensions to include "
                          "(default: common text/source)")
+    pi.add_argument("--exclude", action="append", default=[], metavar="PATTERN",
+                    help="exclude paths matching the given glob pattern "
+                         "(e.g., 'build/*' or '*.min.js'). Can be specified multiple times.")
     pi.set_defaults(func=cmd_index)
 
     ps = sub.add_parser("search", help="query the index")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -256,18 +256,18 @@ def test_index_exclude(tmp_path, capsys):
     build_dir.mkdir()
     (build_dir / "skip.txt").write_text("skip me")
     (tmp_path / "vendor.min.js").write_text("vendor")
-    
+
     rc = run(["index", tmp_path, "--exclude", "build/*", "--exclude", "*.min.js"])
     assert rc == 0
-    
+
     # Check that keep.txt was indexed, but not the others
     capsys.readouterr()
     rc = run(["search", "keep", tmp_path])
     assert rc == 0
     assert "keep.txt" in capsys.readouterr().out
-    
+
     rc = run(["search", "skip", tmp_path])
     assert rc == 1  # Should find no matches
-    
+
     rc = run(["search", "vendor", tmp_path])
     assert rc == 1  # Should find no matches

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,3 +248,26 @@ def test_version_flag_short(capsys):
     out = capsys.readouterr().out
     assert "whoosh" in out.lower()
     assert __version_str__ in out
+
+
+def test_index_exclude(tmp_path, capsys):
+    (tmp_path / "keep.txt").write_text("keep me")
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    (build_dir / "skip.txt").write_text("skip me")
+    (tmp_path / "vendor.min.js").write_text("vendor")
+    
+    rc = run(["index", tmp_path, "--exclude", "build/*", "--exclude", "*.min.js"])
+    assert rc == 0
+    
+    # Check that keep.txt was indexed, but not the others
+    capsys.readouterr()
+    rc = run(["search", "keep", tmp_path])
+    assert rc == 0
+    assert "keep.txt" in capsys.readouterr().out
+    
+    rc = run(["search", "skip", tmp_path])
+    assert rc == 1  # Should find no matches
+    
+    rc = run(["search", "vendor", tmp_path])
+    assert rc == 1  # Should find no matches


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary
Implemented the feature to allow users to specify custom paths to exclude during indexing.

<!-- What does this PR change and why? -->

Made changes to src/whoosh/cli.py-
Added --exclude as a repeatable argument to index command parser
Modified iter_files to accept exclude tuple

test/test_cli.py-
Added test_index_exclude(tmp_path, capsys)
It runs whoosh index . --exclude "build/*" --exclude "*.min.js"

Also updated docs/source/cli.rst - added a section in Index a folder on how to use --exclude flag


## Related issues
Addresses issue #7 
<!-- e.g. Fixes #123 -->

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [x] Added/updated tests for the change where it makes sense
- [x] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
