### PR TITLE
Add field selection to `whoosh search`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Added
+
+- Added repeatable `whoosh search --field NAME` options for restricting a
+  query to equally weighted index fields while preserving the existing
+  defaults when the option is omitted.
+
 ### Changed
 
 - Clarified the package description so PyPI search results make it obvious this

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -93,6 +93,17 @@ Useful options::
     $ whoosh search "index writer" ~/notes --html        # <mark>...</mark> snippets
     $ whoosh search "index writer" ~/notes --json        # JSON array output
     $ whoosh search "index writer" ~/notes --count       # output just the number of matches
+    $ whoosh search "index writer" ~/notes --field title # search titles only
+
+Repeat ``--field`` to search more than one selected field with equal weighting.
+When it is omitted, Whoosh searches ``title`` and ``body`` with the usual title
+boost::
+
+    $ whoosh search "index writer" ~/notes --field title --field body
+
+``--field`` controls which fields are searched. The similarly named
+``--fields`` option accepts a comma-separated list of stored fields to include
+in the output instead.
 
 ``--html`` emits ``<mark>...</mark>`` around matched terms instead of the
 default UPPERCASE highlighting, which is handy when piping results into a web
@@ -151,8 +162,9 @@ How it works
 ``whoosh index`` defines a small schema (``title``, ``path``, ``body``), walks
 the directory, and writes each file into a Whoosh index using the same
 :doc:`indexing` and :doc:`schema` APIs documented here. ``whoosh search``
-opens that index and runs a :doc:`MultifieldParser <parsing>` query across
-``title`` and ``body``, then renders :doc:`highlighted <highlight>` snippets.
+opens that index and runs a :doc:`MultifieldParser <parsing>` query across the
+selected ``--field`` values (``title`` and ``body`` by default), then renders
+:doc:`highlighted <highlight>` snippets.
 ``whoosh stats`` opens the index read-only and reports counts and metadata from
 the reader and the on-disk files.
 

--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -206,9 +206,22 @@ def cmd_search(args: argparse.Namespace) -> int:
         return 2
 
     ix = index.open_dir(index_dir)
-    # Search title + body; title matches are weighted higher.
-    parser = MultifieldParser(["title", "body"], schema=ix.schema,
-                              fieldboosts={"title": 2.0, "body": 1.0})
+    search_fields = args.field or ["title", "body"]
+    for field in search_fields:
+        if field not in ix.schema.names():
+            print(
+                f"whoosh search: error: unknown field {field!r}. "
+                f"Valid fields: {', '.join(ix.schema.names())}",
+                file=sys.stderr,
+            )
+            return 2
+
+    if args.field:
+        parser = MultifieldParser(search_fields, schema=ix.schema)
+    else:
+        # Preserve the existing title/body weighting when no fields are selected.
+        parser = MultifieldParser(search_fields, schema=ix.schema,
+                                  fieldboosts={"title": 2.0, "body": 1.0})
     query = parser.parse(args.query)
 
     with ix.searcher() as s:
@@ -396,6 +409,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="max results (default: 10)")
     ps.add_argument("--fields",
                     help="comma-separated list of stored fields to include in output")
+    ps.add_argument("--field", action="append", metavar="NAME",
+                    help="field to search (repeatable; default: title and body)")
 
     group = ps.add_mutually_exclusive_group()
     group.add_argument("--html", action="store_true",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,6 +147,35 @@ def test_search_limit(corpus, capsys):
     assert "2." not in out
 
 
+def test_search_field_restricts_query(corpus, capsys):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+
+    assert run(["search", "whoosh", corpus]) == 0
+    assert "beta.md" in capsys.readouterr().out
+
+    assert run(["search", "whoosh", corpus, "--field", "title"]) == 1
+    assert "no matches" in capsys.readouterr().out.lower()
+
+    assert run(["search", "whoosh", corpus, "--field", "body"]) == 0
+    assert "beta.md" in capsys.readouterr().out
+
+    assert run([
+        "search", "whoosh", corpus,
+        "--field", "title", "--field", "body",
+    ]) == 0
+    assert "beta.md" in capsys.readouterr().out
+
+
+def test_search_field_invalid(corpus, capsys):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+    rc = run(["search", "whoosh", corpus, "--field", "badfield"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "unknown field" in err.lower()
+
+
 def test_search_fields_invalid(corpus, capsys):
     assert run(["index", corpus]) == 0
     capsys.readouterr()


### PR DESCRIPTION
## Summary

- Add a repeatable `whoosh search --field NAME` option to select query fields.
- Validate selected fields against the index schema and report unknown names clearly.
- Use equal weighting for explicitly selected fields, as agreed with the maintainer.
- Preserve the existing boosted `title` and `body` search when `--field` is omitted.
- Clarify the difference between search-oriented `--field` and display-oriented `--fields` in the CLI documentation and changelog.

## Root cause

`cmd_search` always constructed its parser with the fixed `title` and `body` fields. There was no explicit search-field option; because argparse permits abbreviations, `--field` could instead be interpreted as the existing display-only `--fields` option without restricting the query.

## Testing

Test evidence was collected in a network-disabled Python 3.12 Docker environment:

- Focused CLI suite: 29 passed.
- Complete test suite: 674 passed with four unrelated multiprocessing fork deprecation warnings.
- Scoped Ruff checks passed for `src/whoosh/cli.py` and the modified CLI tests.
- Sphinx HTML documentation build completed with three pre-existing warnings.

The repository-wide Ruff check still reports five pre-existing `PLC0415` findings in `tests/test_cli.py`. A warning-as-error Sphinx build remains blocked by pre-existing/offline documentation issues; the normal HTML build succeeds.

## Risks

The change is limited to CLI field selection. It intentionally does not add custom weighting syntax: explicitly selected fields receive equal weighting, while omitted `--field` arguments retain the existing title boost.

## Related issues

Fixes #14

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [x] Added/updated tests for the change where it makes sense
- [x] Updated docs / CHANGELOG because this is user-facing
- [x] I have read the `CONTRIBUTING.md` guide
