### PR TITLE
feat: add --sort-by mtime option to whoosh search

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -95,6 +95,7 @@ Useful options::
     $ whoosh search "index writer" ~/notes --snippet-chars 80  # shorter snippets
     $ whoosh search "index writer" ~/notes --json           # JSON array output
     $ whoosh search "index writer" ~/notes --count          # output just the number of matches
+    $ whoosh search "index writer" ~/notes --sort-by mtime  # newest files first
     $ whoosh search "index writer" ~/notes --field title    # search titles only
 
 Repeat ``--field`` to search more than one selected field with equal weighting.

--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -231,7 +231,10 @@ def cmd_search(args: argparse.Namespace) -> int:
             print(len(results))
             return 0
 
-        results = s.search(query, limit=args.limit)
+        if getattr(args, "sort_by", "score") == "mtime":
+            results = s.search(query, limit=args.limit, sortedby="mtime", reverse=True)
+        else:
+            results = s.search(query, limit=args.limit)
         snippet_chars = getattr(args, "snippet_chars", 200)
         no_highlight = getattr(args, "no_highlight", False)
         if args.html:
@@ -437,6 +440,10 @@ def build_parser() -> argparse.ArgumentParser:
                     metavar="N", dest="snippet_chars",
                     help="max characters of context to show per snippet "
                          "(default: 200)")
+    ps.add_argument("--sort-by", choices=["score", "mtime"], default="score",
+                    dest="sort_by",
+                    help="sort results by relevance score (default) or "
+                         "file modification time")
 
     # Output style/mode flags are mutually exclusive: the default UPPERCASE
     # text, HTML highlights, a plain grep-friendly slice, machine-readable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for the ``whoosh`` command-line interface (whoosh.cli)."""
-import os
 
+import os
+import time
 import pytest
 
 from whoosh import cli
@@ -403,3 +404,29 @@ def test_human_bytes():
     assert cli._human_bytes(512) == "512 B"
     assert cli._human_bytes(1536).endswith("KB")
     assert cli._human_bytes(5 * 1024 * 1024).endswith("MB")
+
+def test_sort_by_mtime_orders_newest_first(tmp_path, capsys):
+    (tmp_path / "old.txt").write_text("shared search term", encoding="utf-8")
+    time.sleep(1.1)
+    (tmp_path / "new.txt").write_text("shared search term", encoding="utf-8")
+    assert run(["index", tmp_path]) == 0
+    capsys.readouterr()
+
+    rc = run(["search", "shared", tmp_path, "--sort-by", "mtime"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.index("new.txt") < out.index("old.txt")
+
+
+def test_sort_by_default_is_score(tmp_path, capsys):
+    (tmp_path / "old.txt").write_text("shared search term", encoding="utf-8")
+    time.sleep(1.1)
+    (tmp_path / "new.txt").write_text("shared search term", encoding="utf-8")
+    assert run(["index", tmp_path]) == 0
+    capsys.readouterr()
+
+    rc = run(["search", "shared", tmp_path])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "new.txt" in out
+    assert "old.txt" in out


### PR DESCRIPTION
Added a --sort-by flag (choices: score, mtime) to whoosh search. When set to mtime, results are sorted newest-first using sortedby="mtime", reverse=True; the default score behavior is unchanged. --count still returns the true total regardless of sort order.

Added two tests: test_sort_by_mtime_orders_newest_first (verifies newest file appears first with --sort-by mtime) and test_sort_by_default_is_score (confirms default behavior still works). All 37 tests pass.

Also added a short docs example in cli.rst.

Fixes #19