### PR TITLE
feat(cli): add whoosh stats --top-terms FIELD (implements #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Added
+- `whoosh stats --top-terms FIELD` lists the most frequent indexed terms in
+  FIELD, most-frequent-first, with their total frequencies; `--top N` caps
+  the list (default 10). Unknown fields and field types without term
+  frequencies (e.g. NUMERIC/DATETIME) print a friendly error to stderr and
+  exit 2 instead of a traceback. The `--json` payload is unchanged.
+  Implements gh#24.
+
 ### Development
 - Added `benchmark/regression.py`, a deterministic, standard-library-only
   performance-regression harness. It times index build, incremental adds, and

--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -330,7 +330,12 @@ def _human_bytes(n: int) -> str:
 
 
 def cmd_stats(args: argparse.Namespace) -> int:
-    """Print a summary of an existing index: doc count, fields, size on disk."""
+    """Print a summary of an existing index: doc count, fields, size on disk.
+
+    With ``--top-terms FIELD`` also prints the ``--top`` most frequent terms
+    indexed in FIELD. The term listing is human-readable output only; the
+    ``--json`` payload is intentionally unchanged (gh#24).
+    """
     root = os.path.abspath(args.directory)
     index_dir = os.path.join(root, INDEX_DIRNAME)
     if not index.exists_in(index_dir):
@@ -384,6 +389,26 @@ def cmd_stats(args: argparse.Namespace) -> int:
     if latest_mtime:
         stamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(latest_mtime))
         print(f"  last updated: {stamp}")
+
+    if getattr(args, "top_terms", None):
+        fieldname = args.top_terms
+        if fieldname not in schema.names():
+            print(f"error: no field {fieldname!r} in index", file=sys.stderr)
+            return 2
+        try:
+            with ix.reader() as r:
+                top_terms = r.most_frequent_terms(fieldname, number=args.top)
+        except Exception as exc:  # noqa: BLE001
+            # Field types without term frequencies (e.g. NUMERIC, DATETIME)
+            # raise assorted low-level decoding errors; show a clear message
+            # instead of a traceback.
+            print(f"error: cannot list top terms for field {fieldname!r}: {exc}",
+                  file=sys.stderr)
+            return 2
+        print(f"Top terms in {fieldname!r}:")
+        for freq, term in top_terms:
+            text = term.decode("utf-8", "replace")
+            print(f"  {int(freq)}  {text}")
     return 0
 
 
@@ -470,6 +495,10 @@ def build_parser() -> argparse.ArgumentParser:
                      help="directory whose index to inspect (default: current)")
     pst.add_argument("--json", action="store_true",
                      help="emit machine-readable JSON output")
+    pst.add_argument("--top-terms", metavar="FIELD",
+                     help="show the most frequent indexed terms in FIELD")
+    pst.add_argument("--top", type=_check_positive_int, default=10,
+                     help="how many top terms to show (default: 10)")
     pst.set_defaults(func=cmd_stats)
     return p
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,8 @@ import os
 import time
 import pytest
 
-from whoosh import cli
+from whoosh import cli, index
+from whoosh.fields import TEXT, Schema
 
 
 @pytest.fixture()
@@ -27,6 +28,26 @@ def corpus(tmp_path):
     )
     # A binary file that must be skipped.
     (tmp_path / "logo.bin").write_bytes(b"\x00\x01\x02binary\x00")
+    return tmp_path
+
+
+@pytest.fixture()
+def term_index(tmp_path):
+    """Index on disk with known ``body`` term frequencies (apple x3,
+    banana x2, cherry x1).
+
+    Built directly with a plain TEXT field instead of via ``whoosh index``:
+    the CLI schema stems ``body`` terms (StemmingAnalyzer turns "apple" into
+    "appl"), so indexing through the CLI would make exact term assertions
+    impossible. ``whoosh stats`` only needs the index on disk.
+    """
+    index_dir = tmp_path / cli.INDEX_DIRNAME
+    index_dir.mkdir()
+    ix = index.create_in(str(index_dir), Schema(body=TEXT))
+    writer = ix.writer()
+    writer.add_document(body="apple apple apple banana banana")
+    writer.add_document(body="cherry")
+    writer.commit()
     return tmp_path
 
 
@@ -397,6 +418,37 @@ def test_stats_json_output(corpus, capsys):
     assert payload["size_bytes"] > 0
     names = {f["name"] for f in payload["fields"]}
     assert {"path", "title", "body", "mtime"} <= names
+
+
+def test_stats_top_terms_orders_by_frequency(term_index, capsys):
+    rc = run(["stats", term_index, "--top-terms", "body", "--top", "2"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Top terms in 'body':" in out
+    # Frequencies print as ints, most-frequent-first.
+    assert "  3  apple" in out
+    assert "  2  banana" in out
+    assert out.index("apple") < out.index("banana")
+    # --top 2 drops cherry (frequency 1).
+    assert "cherry" not in out
+
+
+def test_stats_top_terms_unknown_field(term_index, capsys):
+    rc = run(["stats", term_index, "--top-terms", "nosuchfield"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "no field 'nosuchfield' in index" in err
+
+
+def test_stats_top_terms_field_without_frequencies(corpus, capsys):
+    """Field types without term frequencies (NUMERIC mtime): clean error."""
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+    rc = run(["stats", corpus, "--top-terms", "mtime"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "cannot list top terms" in err
+    assert "Traceback" not in err
 
 
 def test_human_bytes():


### PR DESCRIPTION
Implements #24.

## What

`whoosh stats --top-terms FIELD [--top N]` — after the existing summary (and after the `--json` early-return, so the JSON payload is untouched per the issue's scope note), the CLI opens a reader and prints `reader.most_frequent_terms(field, number=N)` as a `Top terms in 'body':` header plus `  42  python`-style rows: terms decoded `utf-8/replace`, frequencies as ints. `--top` reuses the file's existing `_check_positive_int` (no new validator), default 10, and the flags sit next to the other `stats` args with the issue's help strings.

Guards, matching the file's existing error style: unknown field → `error: no field 'X' in index` on stderr, exit 2; a field type without stored frequencies (e.g. NUMERIC) → clear stderr message + exit 2, never a traceback.

## Tests + CHANGELOG

Three tests in `tests/test_cli.py` on a fixture index with exact frequencies (apple ×3, banana ×2, cherry ×1): the issue's ordering test (`--top 2`: apple before banana, cherry absent, int rows), the unknown-field test (exit 2 + message), and the frequency-less-field guard (`--top-terms mtime`). CHANGELOG entry added under `[Unreleased]` per CONTRIBUTING. Mutation-checked twice (implementer, then independently re-run before opening): making the code ignore `--top` fails exactly the ordering test; restored → 703 passed.

## Verification

`pip install -e ".[dev]"`; `pytest` → **703 passed**, and the future-proof variant (DeprecationWarning promoted to error, mirroring your CI job) also 703 passed; `ruff check .` — zero new findings vs main; `mypy`-clean not claimed (not in your gates).

---
🤖 This PR was written with AI assistance (implementation: Kimi K3; verification and review: Claude), directed by a human-supervised workflow.