### PR TITLE
Add whoosh index --dry-run to preview files without touching the index (fixes #23)

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -56,6 +56,17 @@ You can exclude specific folders or files using `--exclude` with glob patterns. 
 
     $ whoosh index ~/notes --exclude "build/*" --exclude "*.min.js"
 
+Preview which files *would* be indexed — under the current ``--ext`` and
+``--exclude`` filters — without building anything, using ``--dry-run``. It
+prints one relative path per line to stdout (easy to pipe or ``grep``) and a
+short summary count to stderr, then exits without creating, clearing, or
+writing the ``.whoosh_index`` directory::
+
+    $ whoosh index ~/notes --dry-run --exclude "build/*"
+    ideas.md
+    todo.txt
+    Would index 2 files under /home/you/notes
+
 Re-index incrementally with ``--update``. Only files whose modification time
 changed are re-read, and files that were deleted are dropped from the index —
 so keeping a large tree fresh is cheap::

--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -133,6 +133,24 @@ def cmd_index(args: argparse.Namespace) -> int:
         print(f"error: not a directory: {root}", file=sys.stderr)
         return 2
     exts = _resolve_exts(args.ext)
+
+    # --dry-run: preview which files WOULD be indexed under the current
+    # --ext/--exclude filters, then exit WITHOUT creating, clearing, or
+    # writing the index. Done here, before any index dir is touched, so a
+    # dry run never mutates .whoosh_index. Reuses iter_files so the previewed
+    # set exactly matches a real run.
+    if args.dry_run:
+        rels = sorted(
+            os.path.relpath(full, root)
+            for full, _mtime in iter_files(root, exts, exclude=tuple(args.exclude))
+        )
+        for rel in rels:
+            print(rel)
+        n = len(rels)
+        print(f"Would index {n} file{'s' if n != 1 else ''} under {root}",
+              file=sys.stderr)
+        return 0
+
     index_dir = os.path.join(root, INDEX_DIRNAME)
 
     # For a full (non-incremental) index, start clean.
@@ -447,6 +465,10 @@ def build_parser() -> argparse.ArgumentParser:
     pi.add_argument("--exclude", action="append", default=[], metavar="PATTERN",
                     help="exclude paths matching the given glob pattern "
                          "(e.g., 'build/*' or '*.min.js'). Can be specified multiple times.")
+    pi.add_argument("--dry-run", action="store_true", dest="dry_run",
+                    help="list the files that would be indexed under the "
+                         "current --ext/--exclude filters and exit, without "
+                         "creating, clearing, or writing the index")
     pi.set_defaults(func=cmd_index)
 
     ps = sub.add_parser("search", help="query the index")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -388,6 +388,53 @@ def test_index_exclude(tmp_path, capsys):
     assert rc == 1  # Should find no matches
 
 
+def test_index_dry_run_lists_files_without_touching_index(tmp_path, capsys):
+    """--dry-run lists the files that would be indexed and never creates
+    the index, honoring --ext/--exclude filters."""
+    (tmp_path / "keep.txt").write_text("keep me", encoding="utf-8")
+    (tmp_path / "notes.md").write_text("some notes", encoding="utf-8")
+    # A file whose extension is not indexed by default -> must not be listed.
+    (tmp_path / "photo.png").write_bytes(b"\x89PNG not really text")
+    # A file the exclude filter should drop -> must not be listed.
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    (build_dir / "generated.txt").write_text("generated", encoding="utf-8")
+
+    rc = run(["index", tmp_path, "--dry-run", "--exclude", "build/*"])
+    assert rc == 0
+    out, err = capsys.readouterr()
+
+    # Matching, non-excluded files are listed (one relative path per line).
+    assert "keep.txt" in out
+    assert "notes.md" in out
+    # Non-matching extension is excluded from the listing.
+    assert "photo.png" not in out
+    # Excluded path is excluded from the listing.
+    assert "generated.txt" not in out
+    assert os.path.join("build", "generated.txt") not in out
+    # A short summary count is printed.
+    assert "2 files" in err
+
+    # A dry run must never create/clear/write the index.
+    assert not os.path.isdir(tmp_path / cli.INDEX_DIRNAME)
+
+
+def test_index_dry_run_leaves_existing_index_untouched(corpus, capsys):
+    """--dry-run against an already-indexed directory must not clear or
+    rewrite the existing .whoosh_index."""
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+    index_dir = corpus / cli.INDEX_DIRNAME
+    before = sorted(os.listdir(index_dir))
+
+    rc = run(["index", corpus, "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "alpha.txt" in out
+    # The existing index files are untouched (not cleared or rewritten).
+    assert sorted(os.listdir(index_dir)) == before
+
+
 def test_stats_no_index_errors(tmp_path, capsys):
     rc = run(["stats", tmp_path])
     assert rc == 2


### PR DESCRIPTION
Implements #23, per the issue's sketch, literally:

- `--dry-run` is handled **early** in `cmd_index` — before `index_dir` is even computed, so a dry run can never create, clear, or write `.whoosh_index`.
- It reuses the exact real-run generator (`iter_files(root, exts, exclude=...)`), so the previewed set matches a real run byte-for-byte.
- Output: one relative path per line to **stdout** (sorted, pipeable/greppable), summary count to **stderr** — mirroring the CLI's existing stdout-is-data convention:

```
$ whoosh index ~/notes --dry-run --exclude "build/*"
ideas.md
todo.txt
Would index 2 files under /home/you/notes
```

Tests: the listing honors both filters (fixture includes a wrong-extension file and an excluded file, both asserted absent), no `.whoosh_index` exists afterward, and a dry run against an *already-indexed* directory leaves the existing index byte-listing untouched. Mutation-proven (re-run independently before opening): making `--dry-run` fall through into indexing fails both tests; dropping `exclude=` from the dry-run call makes the excluded file appear and fails the assertion. Docs: a `--dry-run` block in `cli.rst` styled after the `--exclude` example.

Two semantics notes for your review, both deliberate:
1. The preview shows the full **candidate set** from the filters, independent of `--update` — simulating `--update`'s changed-only subset would require reading the existing index, which the issue forbids.
2. Files the real run later skips as binary (null-byte check in `read_text`) *are* listed if their extension matches, because the preview reuses `iter_files` as instructed and the binary skip happens later. Rarely matters in practice; happy to add a note or a probe if you'd rather.

Gates: full suite 716 → 718 passed, also green with DeprecationWarnings promoted to errors (your future-proof job); ruff clean on the touched files (repo-wide ruff is unchanged, CI runs it non-blocking).

---
Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (1M context) (implementation)
