### PR TITLE
Add whoosh index --max-size SIZE to skip files above a size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
-## [3.18.4] - 2026-07-19
-
 ### Added
 - CLI: `whoosh index --max-size SIZE` skips files larger than `SIZE` before
   they're read (e.g. `10MB`, `500k`, `2048`). Accepts a bare integer (bytes)
   or a `k`/`m`/`g` suffix, case-insensitive, with or without a trailing `b`.
   No `--max-size` given -> unchanged behavior. `--dry-run` respects it too.
   (#30)
+
+## [3.18.4] - 2026-07-19
 
 ### Added
 - CLI: `whoosh search --or` matches documents containing **any** query term

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to this project are documented here. This project follows
 ## [3.18.4] - 2026-07-19
 
 ### Added
+- CLI: `whoosh index --max-size SIZE` skips files larger than `SIZE` before
+  they're read (e.g. `10MB`, `500k`, `2048`). Accepts a bare integer (bytes)
+  or a `k`/`m`/`g` suffix, case-insensitive, with or without a trailing `b`.
+  No `--max-size` given -> unchanged behavior. `--dry-run` respects it too.
+  (#30)
+
+### Added
 - CLI: `whoosh search --or` matches documents containing **any** query term
   (broader recall) instead of requiring all terms. Uses `OrGroup.factory(0.9)`
   so documents matching more terms still rank higher. (#18)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ $ whoosh search "full text search" ~/notes
 - Query language: `AND`/`OR`/`NOT`, `"exact phrases"`, and `field:term`.
 - `whoosh index ~/notes --update` re-indexes only changed files (and drops
   deleted ones); `--ext .md,.txt` limits which files are picked up.
+  `--max-size 10MB` skips files larger than the given size.
 - `whoosh stats ~/notes` prints a quick summary of an index — document count,
   fields, size on disk, and when it was last updated (`--json` for scripts).
 

--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import time
 from pathlib import PurePath
@@ -53,7 +54,8 @@ DEFAULT_EXTS: tuple[str, ...] = (
 )
 INDEX_DIRNAME = ".whoosh_index"
 MAX_FILE_BYTES = 5_000_000  # skip anything larger; keeps indexing snappy
-
+_SIZE_RE = re.compile(r"^\s*(\d+)\s*([kmg]?)b?\s*$", re.IGNORECASE)
+_SIZE_MULTIPLIERS = {"": 1, "k": 1024, "m": 1024 ** 2, "g": 1024 ** 3}
 
 def build_schema() -> Schema:
     """Schema: a stored path/title, a stemmed full-text body, and mtime.
@@ -68,10 +70,12 @@ def build_schema() -> Schema:
     )
 
 
-def iter_files(root: str, exts: tuple[str, ...], exclude: tuple[str, ...] = ()):
+def iter_files(root: str, exts: tuple[str, ...], exclude: tuple[str, ...] = (),
+                max_size: int | None = None):
     """Yield ``(abspath, mtime)`` for files under *root* matching *exts*.
 
-    Skips the index directory itself and common noise directories.
+    Skips the index directory itself and common noise directories. Files
+    larger than *max_size* bytes are skipped as well, if given.
     """
     skip = {INDEX_DIRNAME, ".git", ".hg", "__pycache__", "node_modules", ".venv"}
     for dirpath, dirnames, filenames in os.walk(root):
@@ -92,6 +96,12 @@ def iter_files(root: str, exts: tuple[str, ...], exclude: tuple[str, ...] = ()):
             rel_f = os.path.relpath(full, root)
             if any(PurePath(rel_f).match(pat) for pat in exclude):
                 continue
+            if max_size is not None:
+                try:
+                    if os.path.getsize(full) > max_size:
+                        continue
+                except OSError:
+                    continue
             try:
                 yield full, os.path.getmtime(full)
             except OSError:
@@ -142,7 +152,8 @@ def cmd_index(args: argparse.Namespace) -> int:
     if args.dry_run:
         rels = sorted(
             os.path.relpath(full, root)
-            for full, _mtime in iter_files(root, exts, exclude=tuple(args.exclude))
+            for full, _mtime in iter_files(root, exts, exclude=tuple(args.exclude),
+                                            max_size=args.max_size)
         )
         for rel in rels:
             print(rel)
@@ -172,7 +183,8 @@ def cmd_index(args: argparse.Namespace) -> int:
     t0 = time.time()
     writer = ix.writer()
     try:
-        for full, mtime in iter_files(root, exts, exclude=tuple(args.exclude)):
+        for full, mtime in iter_files(root, exts, exclude=tuple(args.exclude),
+                                        max_size=args.max_size):
             rel = os.path.relpath(full, root)
             seen.add(rel)
             if args.update and rel in indexed and indexed[rel] >= mtime:
@@ -460,6 +472,15 @@ def _check_positive_int(value: str) -> int:
     return ivalue
 
 
+def _parse_size(value):
+    match = _SIZE_RE.match(value)
+    if not match:
+        raise argparse.ArgumentTypeError(f"invalid size {value!r}: expected e.g. 1024, 500k, 10MB, 2g")
+    number, unit = match.groups()
+    multiplier = _SIZE_MULTIPLIERS[unit.lower()]
+    return int(number) * multiplier
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="whoosh",
@@ -488,6 +509,10 @@ def build_parser() -> argparse.ArgumentParser:
     pi.add_argument("--exclude", action="append", default=[], metavar="PATTERN",
                     help="exclude paths matching the given glob pattern "
                          "(e.g., 'build/*' or '*.min.js'). Can be specified multiple times.")
+    pi.add_argument("--max-size", type=_parse_size, default=None,
+                    dest="max_size", metavar="SIZE",
+                    help="skip files larger than SIZE (e.g. 10MB, 500k); "
+                     "no limit by default")
     pi.add_argument("--dry-run", action="store_true", dest="dry_run",
                     help="list the files that would be indexed under the "
                          "current --ext/--exclude filters and exit, without "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the ``whoosh`` command-line interface (whoosh.cli)."""
 
+import argparse
 import os
 import time
 import pytest
@@ -179,6 +180,26 @@ def test_search_snippet_chars_rejects_nonpositive(corpus, capsys):
 def test_resolve_exts_normalizes():
     assert cli._resolve_exts("md,.txt") == (".md", ".txt")
     assert cli._resolve_exts("") == cli.DEFAULT_EXTS
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("1024", 1024),
+    ("500k", 500 * 1024),
+    ("500K", 500 * 1024),
+    ("10MB", 10 * 1024 * 1024),
+    ("2g", 2 * 1024 ** 3),
+    ("2Gb", 2 * 1024 ** 3),
+])  
+
+
+def test_parse_size_valid(raw, expected):
+    assert cli._parse_size(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["", "abc", "10XB", "-5", "5.5m", "10 MB!"])
+def test_parse_size_invalid(raw):
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli._parse_size(raw)
 
 
 def test_search_json_output(corpus, capsys):
@@ -458,6 +479,34 @@ def test_index_dry_run_leaves_existing_index_untouched(corpus, capsys):
     assert "alpha.txt" in out
     # The existing index files are untouched (not cleared or rewritten).
     assert sorted(os.listdir(index_dir)) == before
+
+
+def test_index_max_size_skips_large_files(tmp_path, capsys):
+    (tmp_path / "small.txt").write_text("apple " * 20, encoding="utf-8")
+    (tmp_path / "big.txt").write_text("apple " * 1000, encoding="utf-8")
+
+    rc = run(["index", tmp_path, "--max-size", "1k"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "1 added" in out
+
+    capsys.readouterr()
+    rc = run(["search", "apple", tmp_path])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "small.txt" in out
+    assert "big.txt" not in out
+
+
+def test_index_max_size_dry_run_matches_real_run(tmp_path, capsys):
+    (tmp_path / "small.txt").write_text("apple " * 20, encoding="utf-8")
+    (tmp_path / "big.txt").write_text("apple " * 1000, encoding="utf-8")
+
+    rc = run(["index", tmp_path, "--max-size", "1k", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "small.txt" in out
+    assert "big.txt" not in out
 
 
 def test_stats_no_index_errors(tmp_path, capsys):


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

Adds a `whoosh index --max-size SIZE` option that skips files larger than the given size before they're read (e.g. `--max-size 10MB`, `--max-size 500k`, `--max-size 2048`).

- New `_parse_size()` helper in `cli.py`: parses a size string into bytes, accepting a bare int or `k`/`m`/`g` suffixes (case-insensitive, optional trailing `b`). Raises `argparse.ArgumentTypeError` on invalid input, mirroring `_check_positive_int`.
- New `--max-size` argument on the `index` subparser.
- Size filtering happens in `iter_files()` so `--dry-run` and the real run always agree.
- No `--max-size` given → behaviour unchanged.

## Related issues

Fixes #30

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [x] Added/updated tests for the change where it makes sense
- [x] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
