### PR TITLE
feat(cli): add JSONL search output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Added
+- CLI: `whoosh search --jsonl` (alias `--ndjson`) emits one JSON object per
+  match for line-oriented processing. No matches produces no output and exits
+  with status `1`. (#32)
+
 ## [3.18.7] - 2026-07-20
 
 ### Fixed

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -105,6 +105,7 @@ Useful options::
     $ whoosh search "index writer" ~/notes --no-highlight   # plain, grep-friendly snippets
     $ whoosh search "index writer" ~/notes --snippet-chars 80  # shorter snippets
     $ whoosh search "index writer" ~/notes --json           # JSON array output
+    $ whoosh search "index writer" ~/notes --jsonl          # JSON Lines output
     $ whoosh search "index writer" ~/notes --count          # output just the number of matches
     $ whoosh search "index writer" ~/notes --sort-by mtime  # newest files first
     $ whoosh search "index writer" ~/notes --field title    # search titles only
@@ -138,16 +139,25 @@ tokens get in the way.
 
 ``--snippet-chars N`` sets the maximum number of characters shown per snippet
 (default 200). It applies to the default text output, ``--no-highlight``, and
-the ``snippet`` field of ``--json`` output.
+the ``snippet`` field of ``--json`` and ``--jsonl`` output.
 
 ``--json`` emits a machine-readable JSON array of matches, making it easy to
 parse results with tools like ``jq``.
 
-The output-style flags (``--html``, ``--no-highlight``, ``--json`` and
-``--count``) are mutually exclusive.
+``--jsonl`` (alias ``--ndjson``) emits newline-delimited JSON (JSON Lines):
+one standalone object per match, with the same fields as an element of the
+``--json`` array. There are no surrounding brackets or trailing commas, so
+line-oriented tools can process each match as soon as it is written. No matches
+produces no output and exits with status ``1``::
+
+    $ whoosh search "install guide" --jsonl | jq -c 'select(.score > 1.5)'
+
+The output-style flags (``--html``, ``--no-highlight``, ``--json``,
+``--jsonl``/``--ndjson`` and ``--count``) are mutually exclusive.
 
 ``--count`` prints only the total number of matching documents as a single integer
-and exits, which is great for shell pipelines (mutually exclusive with ``--json`` and ``--html``).
+and exits, which is great for shell pipelines. As an output-style flag, it
+cannot be combined with the other modes above.
 
 
 Inspect an index

--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -311,29 +311,38 @@ def cmd_search(args: argparse.Namespace) -> int:
                     print(f"whoosh search: error: unknown field {f!r}. Valid fields: {', '.join(ix.schema.names())}", file=sys.stderr)
                     return 2
 
+        def make_hit_dict(hit):
+            if fields_to_show:
+                return {f: hit[f] for f in fields_to_show if f in hit}
+            hit_dict = {
+                "path": hit["path"],
+                "score": hit.score,
+                "snippet": make_snippet(hit)
+            }
+            if "title" in hit and hit["title"]:
+                hit_dict["title"] = hit["title"]
+            return hit_dict
+
+        json_output = getattr(args, "json", False)
+        jsonl_output = getattr(args, "jsonl", False)
         n = len(results)
         if n == 0:
-            if getattr(args, "json", False):
+            if json_output:
                 print(json.dumps([]))
-                return 1
-            print(f"No matches for: {args.query!r}")
+            elif not jsonl_output:
+                print(f"No matches for: {args.query!r}")
             return 1
 
-        if getattr(args, "json", False):
+        if json_output or jsonl_output:
             json_results = []
-            for i, hit in enumerate(results, 1):
-                if fields_to_show:
-                    hit_dict = {f: hit[f] for f in fields_to_show if f in hit}
+            for hit in results:
+                hit_dict = make_hit_dict(hit)
+                if jsonl_output:
+                    print(json.dumps(hit_dict))
                 else:
-                    hit_dict = {
-                        "path": hit["path"],
-                        "score": hit.score,
-                        "snippet": make_snippet(hit)
-                    }
-                    if "title" in hit and hit["title"]:
-                        hit_dict["title"] = hit["title"]
-                json_results.append(hit_dict)
-            print(json.dumps(json_results))
+                    json_results.append(hit_dict)
+            if json_output:
+                print(json.dumps(json_results))
             return 0
 
         print(f"{n} match{'es' if n != 1 else ''} for {args.query!r}:\n")
@@ -545,8 +554,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     # Output style/mode flags are mutually exclusive: the default UPPERCASE
     # text, HTML highlights, a plain grep-friendly slice, machine-readable
-    # JSON, or a bare count. (JSON snippets are already plain, so combining
-    # --no-highlight with --json would be redundant.)
+    # JSON/JSONL, or a bare count. (JSON snippets are already plain, so
+    # combining --no-highlight with --json/--jsonl would be redundant.)
     group = ps.add_mutually_exclusive_group()
     group.add_argument("--html", action="store_true",
                     help="emit <mark>...</mark> HTML highlights instead of "
@@ -558,6 +567,8 @@ def build_parser() -> argparse.ArgumentParser:
     group.add_argument("--json", action="store_true",
                     help="emit machine-readable JSON output instead of "
                          "human-readable text")
+    group.add_argument("--jsonl", "--ndjson", action="store_true",
+                    help="emit newline-delimited JSON (one object per hit)")
     group.add_argument("--count", action="store_true",
                     help="emit only the number of matching documents")
     ps.set_defaults(func=cmd_search)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,10 @@
 """Tests for the ``whoosh`` command-line interface (whoosh.cli)."""
 
 import argparse
+import json
 import os
 import time
+
 import pytest
 
 from whoosh import cli, index
@@ -208,13 +210,74 @@ def test_search_json_output(corpus, capsys):
     rc = run(["search", "whoosh", corpus, "--json"])
     assert rc == 0
     out = capsys.readouterr().out
-    import json
     data = json.loads(out)
     assert isinstance(data, list)
     assert len(data) > 0
     assert "path" in data[0]
     assert "score" in data[0]
     assert "snippet" in data[0]
+
+
+@pytest.mark.parametrize("flag", ["--jsonl", "--ndjson"])
+def test_search_jsonl_output(corpus, capsys, flag):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+    rc = run(["search", "search", corpus, flag])
+    assert rc == 0
+    out = capsys.readouterr().out
+    lines = out.splitlines()
+    data = [json.loads(line) for line in lines]
+    assert len(data) == 2
+    assert not out.startswith("[")
+    for hit in data:
+        assert "path" in hit
+        assert "score" in hit
+        assert "snippet" in hit
+
+    assert run(["search", "search", corpus, "--json"]) == 0
+    assert data == json.loads(capsys.readouterr().out)
+
+
+@pytest.mark.parametrize("flag", ["--jsonl", "--ndjson"])
+def test_search_jsonl_no_matches(corpus, capsys, flag):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+    rc = run(["search", "zzzznottherezzz", corpus, flag])
+    assert rc == 1
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""
+
+
+def test_search_json_no_matches_remains_array(corpus, capsys):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+    rc = run(["search", "zzzznottherezzz", corpus, "--json"])
+    assert rc == 1
+    assert capsys.readouterr().out == "[]\n"
+
+
+@pytest.mark.parametrize("flag", ["--jsonl", "--ndjson"])
+@pytest.mark.parametrize(
+    "other", ["--json", "--html", "--no-highlight", "--count"])
+def test_search_jsonl_is_mutually_exclusive(corpus, capsys, flag, other):
+    with pytest.raises(SystemExit):
+        run(["search", "whoosh", corpus, flag, other])
+    err = capsys.readouterr().err
+    assert "not allowed with argument" in err.lower()
+
+
+def test_search_jsonl_fields_and_limit(corpus, capsys):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+    rc = run([
+        "search", "search", corpus, "--jsonl", "--fields", "path",
+        "--limit", "1",
+    ])
+    assert rc == 0
+    lines = capsys.readouterr().out.splitlines()
+    assert len(lines) == 1
+    assert set(json.loads(lines[0])) == {"path"}
 
 
 def test_search_mutually_exclusive_json_html(corpus, capsys):
@@ -286,7 +349,6 @@ def test_search_fields_json(corpus, capsys):
     rc = run(["search", "whoosh", corpus, "--json", "--fields", "path"])
     assert rc == 0
     out = capsys.readouterr().out
-    import json
     data = json.loads(out)
     assert len(data) > 0
     assert "path" in data[0]
@@ -529,12 +591,11 @@ def test_stats_text_output(corpus, capsys):
 
 
 def test_stats_json_output(corpus, capsys):
-    import json as _json
     run(["index", corpus])
     capsys.readouterr()
     rc = run(["stats", corpus, "--json"])
     assert rc == 0
-    payload = _json.loads(capsys.readouterr().out)
+    payload = json.loads(capsys.readouterr().out)
     assert payload["doc_count"] >= 1
     assert payload["size_bytes"] > 0
     names = {f["name"] for f in payload["fields"]}
@@ -593,6 +654,14 @@ def test_sort_by_mtime_orders_newest_first(tmp_path, capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert out.index("new.txt") < out.index("old.txt")
+
+    rc = run(["search", "shared", tmp_path, "--sort-by", "mtime", "--jsonl"])
+    assert rc == 0
+    paths = [
+        hit["path"]
+        for hit in map(json.loads, capsys.readouterr().out.splitlines())
+    ]
+    assert paths.index("new.txt") < paths.index("old.txt")
 
 
 def test_sort_by_default_is_score(tmp_path, capsys):


### PR DESCRIPTION
Closes #32.

## Summary

The search command now supports `--jsonl` and `--ndjson` for
newline-delimited JSON output. Each matching hit is emitted as a standalone
JSON object while preserving the existing `--json` result shape.

Tests cover both aliases, output-mode conflicts, empty results, field
selection, limits, and sorting. The CLI documentation and changelog include
the new output mode.

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [x] Added/updated tests for the change where it makes sense
- [x] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide