### PR TITLE
feat(cli): add paginated search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Added
+- CLI: `whoosh search --page N` pages through results using `--limit` as the
+  page size, while keeping JSON, JSON Lines, and count output machine-friendly.
+
 ## [3.19.0] - 2026-07-21
 
 ### Added

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -101,6 +101,7 @@ The query supports Whoosh's full query language:
 Useful options::
 
     $ whoosh search "index writer" ~/notes --limit 20       # show up to 20 hits
+    $ whoosh search "index writer" ~/notes --limit 20 --page 2  # show the next page
     $ whoosh search "index writer" ~/notes --html           # <mark>...</mark> snippets
     $ whoosh search "index writer" ~/notes --no-highlight   # plain, grep-friendly snippets
     $ whoosh search "index writer" ~/notes --snippet-chars 80  # shorter snippets
@@ -110,6 +111,10 @@ Useful options::
     $ whoosh search "index writer" ~/notes --sort-by mtime  # newest files first
     $ whoosh search "index writer" ~/notes --field title    # search titles only
     $ whoosh search "index writer" ~/notes --or             # match ANY term, not all
+
+``--page N`` selects a 1-based page of results, with ``--limit`` as the page
+size. Page 1 is the default. Human-readable output includes page metadata after
+the first page; JSON, JSON Lines, and count output remain machine-friendly.
 
 By default a multi-term query such as ``index writer`` requires **both** terms
 to appear in a document (``index AND writer``). Pass ``--or`` to match documents

--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -271,17 +271,30 @@ def cmd_search(args: argparse.Namespace) -> int:
             print(len(results))
             return 0
 
+        search_kwargs = {}
         if getattr(args, "sort_by", "score") == "mtime":
-            results = s.search(query, limit=args.limit, sortedby="mtime", reverse=True)
-        else:
-            results = s.search(query, limit=args.limit)
+            search_kwargs.update(sortedby="mtime", reverse=True)
+        results = s.search_page(
+            query, args.page, pagelen=args.limit, **search_kwargs)
+
+        # ResultsPage clamps an oversized page number to the last available
+        # page. The CLI should instead treat it like an empty search so users
+        # do not accidentally see the same final page for every larger value.
+        if results.total and args.page > results.pagecount:
+            if getattr(args, "json", False):
+                print(json.dumps([]))
+            elif not getattr(args, "jsonl", False):
+                print(f"No matches for: {args.query!r}")
+            return 1
+
         snippet_chars = getattr(args, "snippet_chars", 200)
         no_highlight = getattr(args, "no_highlight", False)
+        highlight_results = results.results
         if args.html:
-            results.formatter = HtmlFormatter(tagname="mark")
+            highlight_results.formatter = HtmlFormatter(tagname="mark")
         else:
-            results.formatter = UppercaseFormatter()
-        results.fragmenter = ContextFragmenter(
+            highlight_results.formatter = UppercaseFormatter()
+        highlight_results.fragmenter = ContextFragmenter(
             maxchars=snippet_chars, surround=snippet_chars // 5)
 
         def make_snippet(hit):
@@ -347,7 +360,7 @@ def cmd_search(args: argparse.Namespace) -> int:
 
         print(f"{n} match{'es' if n != 1 else ''} for {args.query!r}:\n")
         shown = 0
-        for i, hit in enumerate(results, 1):
+        for i, hit in enumerate(results, results.offset + 1):
             shown += 1
             if fields_to_show:
                 fields_str = ", ".join(f"{f}: {hit[f]}" for f in fields_to_show if f in hit)
@@ -359,7 +372,13 @@ def cmd_search(args: argparse.Namespace) -> int:
         if getattr(args, "count", False) or getattr(args, "json", False) or getattr(args, "html", False):
             pass
         else:
-            if n > shown:
+            if args.page > 1:
+                print(
+                    f"Page {results.pagenum}/{results.pagecount} "
+                    f"({results.total} total).",
+                    file=sys.stderr,
+                )
+            elif n > shown:
                 print(f"Showing {shown} of {n} matches.", file=sys.stderr)
             else:
                 print(f"{n} match{'es' if n != 1 else ''}.", file=sys.stderr)
@@ -536,6 +555,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="directory whose index to search (default: current)")
     ps.add_argument("--limit", type=_check_positive_int, default=10,
                     help="max results (default: 10)")
+    ps.add_argument("--page", type=_check_positive_int, default=1,
+                    help="1-based results page (default: 1)")
     ps.add_argument("--fields",
                     help="comma-separated list of stored fields to include in output")
     ps.add_argument("--field", action="append", metavar="NAME",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,7 +191,7 @@ def test_resolve_exts_normalizes():
     ("10MB", 10 * 1024 * 1024),
     ("2g", 2 * 1024 ** 3),
     ("2Gb", 2 * 1024 ** 3),
-])  
+])
 
 
 def test_parse_size_valid(raw, expected):
@@ -303,6 +303,62 @@ def test_search_limit(corpus, capsys):
     out = capsys.readouterr().out
     assert out.count("1.") == 1
     assert "2." not in out
+
+
+def test_search_pages_cover_the_same_hits_as_one_large_page(corpus, capsys):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+
+    pages = []
+    for page in (1, 2):
+        assert run([
+            "search", "search", corpus, "--json", "--fields", "path",
+            "--limit", "1", "--page", str(page),
+        ]) == 0
+        pages.extend(json.loads(capsys.readouterr().out))
+
+    assert run([
+        "search", "search", corpus, "--json", "--fields", "path",
+        "--limit", "2",
+    ]) == 0
+    all_at_once = json.loads(capsys.readouterr().out)
+    assert pages == all_at_once
+
+
+def test_search_page_footer_and_global_result_number(corpus, capsys):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+
+    assert run(["search", "search", corpus, "--limit", "1", "--page", "2"]) == 0
+    out, err = capsys.readouterr()
+    assert "2." in out
+    assert "Page 2/2 (2 total)." in err
+
+
+def test_search_page_rejects_nonpositive_values(corpus, capsys):
+    with pytest.raises(SystemExit):
+        run(["search", "search", corpus, "--page", "0"])
+    assert "invalid positive int value" in capsys.readouterr().err.lower()
+
+
+def test_search_page_beyond_last_is_empty(corpus, capsys):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+
+    assert run(["search", "search", corpus, "--limit", "1", "--page", "3"]) == 1
+    assert "No matches" in capsys.readouterr().out
+
+    assert run([
+        "search", "search", corpus, "--json", "--limit", "1", "--page", "3",
+    ]) == 1
+    assert capsys.readouterr().out == "[]\n"
+
+
+def test_search_count_ignores_page_and_reports_total(corpus, capsys):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+    assert run(["search", "search", corpus, "--count", "--page", "2"]) == 0
+    assert capsys.readouterr().out.strip() == "2"
 
 
 def test_search_field_restricts_query(corpus, capsys):


### PR DESCRIPTION
## Summary

Add 1-based pagination to `whoosh search` through a new `--page N` option, using `--limit` as the page size.

## Changes

- Use `Searcher.search_page()` for CLI result paging.
- Preserve JSON, JSON Lines, count, highlighting, field selection, and mtime sorting behavior.
- Return an empty result with exit code 1 when the requested page is beyond the last page.
- Add human-readable page metadata after the first page.
- Document the new option and update the Unreleased changelog.
- Add regression tests for page coverage, numbering, validation, out-of-range pages, JSON, and count output.

## Testing

- `python -m pytest -q`: 772 passed, 3 skipped
- `python -m pytest tests/test_cli.py -q`: 77 passed
- Changed-file Ruff check: passed
- Full-repository Ruff currently reports pre-existing baseline violations unrelated to this change.

Fixes #34