### PR TITLE
Add -l/--files-with-matches to print bare file paths (grep -l style)

### DIFF
--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -287,6 +287,15 @@ def cmd_search(args: argparse.Namespace) -> int:
                 print(f"No matches for: {args.query!r}")
             return 1
 
+        # --files-with-matches: print bare file paths, one per hit.
+        if getattr(args, "files_with_matches", False):
+            n = len(results)
+            if n == 0:
+                return 1
+            for hit in results:
+                print(hit["path"])
+            return 0
+
         snippet_chars = getattr(args, "snippet_chars", 200)
         no_highlight = getattr(args, "no_highlight", False)
         highlight_results = results.results
@@ -592,6 +601,10 @@ def build_parser() -> argparse.ArgumentParser:
                     help="emit newline-delimited JSON (one object per hit)")
     group.add_argument("--count", action="store_true",
                     help="emit only the number of matching documents")
+    group.add_argument("-l", "--files-with-matches", action="store_true",
+                    dest="files_with_matches",
+                    help="print just matching file paths, one per line "
+                         "(grep -l style, newline-separated)")
     ps.set_defaults(func=cmd_search)
 
     pst = sub.add_parser("stats",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -732,3 +732,53 @@ def test_sort_by_default_is_score(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "new.txt" in out
     assert "old.txt" in out
+
+
+def test_search_files_with_matches_prints_paths(corpus, capsys):
+    """-l prints one bare path per match, newline-separated, no scores/snippets."""
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+    rc = run(["search", "search", corpus, "-l"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    lines = out.splitlines()
+    assert len(lines) == 2
+    for line in lines:
+        assert line.endswith(".txt") or line.endswith(".md") or line.endswith(".rst")
+    assert "alpha.txt" in out
+    assert "beta.md" in out
+
+
+def test_search_files_with_matches_no_matches_returns_1(corpus, capsys):
+    """-l with no matches -> empty stdout, exit 1."""
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+    rc = run(["search", "zzzznottherezzz", corpus, "-l"])
+    assert rc == 1
+    assert capsys.readouterr().out == ""
+
+
+def test_search_files_with_matches_honors_limit_and_page(corpus, capsys):
+    """-l respects --limit and --page."""
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+    rc = run(["search", "search", corpus, "-l", "--limit", "1"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert len(out.splitlines()) == 1
+
+    # Second page should contain the second result.
+    rc = run(["search", "search", corpus, "-l", "--limit", "1", "--page", "2"])
+    assert rc == 0
+    out2 = capsys.readouterr().out
+    assert len(out2.splitlines()) == 1
+    assert out != out2  # Different hit on second page
+
+
+def test_search_files_with_matches_is_mutually_exclusive(corpus, capsys):
+    """-l conflicts with other output modes."""
+    for other in ("--html", "--no-highlight", "--json", "--jsonl", "--count"):
+        with pytest.raises(SystemExit):
+            run(["search", "search", corpus, "-l", other])
+        err = capsys.readouterr().err
+        assert "not allowed with argument" in err.lower()


### PR DESCRIPTION
## Summary

Adds a `-l` / `--files-with-matches` flag to `whoosh search` that prints
**one bare file path per matching hit**, newline-separated, with no scores,
snippets, or numbering. Perfect for piping into `xargs`, `wc -l`, editors, etc.

```console
$ whoosh search "index writer" ~/notes -l
/home/me/notes/indexing.md
/home/me/notes/writer-internals.md

$ whoosh search "index writer" ~/notes -l | xargs wc -l
```

Closes issue #36.

## Changes

- **Parser** (`build_parser`): Added `-l`/`--files-with-matches` to the mutually
  exclusive output-mode group in the search subparser.
- **Logic** (`cmd_search`): Early branch after page computation that iterates
  the result page and prints `hit["path"]` for each match, then returns 0/1.
  Skips highlighting setup entirely (same pattern as `--count`).
- **Tests**: Four new tests covering:
  - Prints one path per match, newline-separated
  - No matches -> empty stdout, exit 1
  - Honors `--limit` and `--page`
  - Mutually exclusive with other output modes (`--html`, `--no-highlight`,
    `--json`, `--jsonl`, `--count`)

## Verification

All 81 tests pass (including 4 new):

```
tests/test_cli.py::test_search_files_with_matches_prints_paths PASSED
tests/test_cli.py::test_search_files_with_matches_no_matches_returns_1 PASSED
tests/test_cli.py::test_search_files_with_matches_honors_limit_and_page PASSED
tests/test_cli.py::test_search_files_with_matches_is_mutually_exclusive PASSED
```

## Notes

- Uses the existing search_page flow so `--limit` and `--page` work naturally.
  No new dependencies or refactoring needed.
- The exit-code convention matches `--jsonl`: no matches -> exit 1, empty stdout.
- Closes issue #36.