### PR TITLE
Add `whoosh index --follow-symlinks` to index through symlinked directories

### DIFF
--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -71,14 +71,17 @@ def build_schema() -> Schema:
 
 
 def iter_files(root: str, exts: tuple[str, ...], exclude: tuple[str, ...] = (),
-                max_size: int | None = None):
+                max_size: int | None = None, follow_symlinks: bool = False):
     """Yield ``(abspath, mtime)`` for files under *root* matching *exts*.
 
     Skips the index directory itself and common noise directories. Files
     larger than *max_size* bytes are skipped as well, if given.
+
+    When *follow_symlinks* is ``True``, ``os.walk`` follows symlinked
+    directories (off by default for safety).
     """
     skip = {INDEX_DIRNAME, ".git", ".hg", "__pycache__", "node_modules", ".venv"}
-    for dirpath, dirnames, filenames in os.walk(root):
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=follow_symlinks):
         new_dirnames = []
         for d in dirnames:
             if d in skip:
@@ -153,7 +156,8 @@ def cmd_index(args: argparse.Namespace) -> int:
         rels = sorted(
             os.path.relpath(full, root)
             for full, _mtime in iter_files(root, exts, exclude=tuple(args.exclude),
-                                            max_size=args.max_size)
+                                            max_size=args.max_size,
+                                            follow_symlinks=args.follow_symlinks)
         )
         for rel in rels:
             print(rel)
@@ -184,7 +188,8 @@ def cmd_index(args: argparse.Namespace) -> int:
     writer = ix.writer()
     try:
         for full, mtime in iter_files(root, exts, exclude=tuple(args.exclude),
-                                        max_size=args.max_size):
+                                        max_size=args.max_size,
+                                        follow_symlinks=args.follow_symlinks):
             rel = os.path.relpath(full, root)
             seen.add(rel)
             if args.update and rel in indexed and indexed[rel] >= mtime:
@@ -554,6 +559,10 @@ def build_parser() -> argparse.ArgumentParser:
                     help="list the files that would be indexed under the "
                          "current --ext/--exclude filters and exit, without "
                          "creating, clearing, or writing the index")
+    pi.add_argument("--follow-symlinks", action="store_true",
+                    dest="follow_symlinks",
+                    help="follow symlinked directories when indexing "
+                         "(off by default)")
     pi.set_defaults(func=cmd_index)
 
     ps = sub.add_parser("search", help="query the index")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -782,3 +782,64 @@ def test_search_files_with_matches_is_mutually_exclusive(corpus, capsys):
             run(["search", "search", corpus, "-l", other])
         err = capsys.readouterr().err
         assert "not allowed with argument" in err.lower()
+
+
+def test_index_follow_symlinks_includes_symlinked_directories(tmp_path, capsys):
+    """--follow-symlinks indexes files reachable only through a symlink.
+
+    Creates a target directory outside the indexed root, then a symlink to
+    it under the indexed root. Without --follow-symlinks the symlinked file
+    is invisible to os.walk; with it, the file should be indexed.
+    """
+    # Target directory OUTSIDE the indexed root.
+    target = tmp_path / ".." / "outside_content"
+    target = target.resolve()
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "outside.txt").write_text("secret content behind symlink",
+                                       encoding="utf-8")
+
+    # Symlink inside the indexed root pointing outside -> ../outside_content/
+    link = tmp_path / "link_to_outside"
+    os.symlink(target, link, target_is_directory=True)
+
+    # Index without --follow-symlinks -> symlinked dir skipped.
+    rc = run(["index", tmp_path])
+    assert rc == 0
+    capsys.readouterr()
+
+    rc = run(["search", "secret", tmp_path])
+    assert rc == 1  # No matches
+
+    # Now index WITH --follow-symlinks.
+    rc = run(["index", tmp_path, "--follow-symlinks"])
+    assert rc == 0
+    capsys.readouterr()
+
+    rc = run(["search", "secret", tmp_path])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "outside.txt" in out
+
+
+def test_index_follow_symlinks_dry_run_matches_real_run(tmp_path, capsys):
+    """--dry-run with --follow-symlinks previews the same files."""
+    target = tmp_path / ".." / "outside_content"
+    target = target.resolve()
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "outside.txt").write_text("secret content behind symlink",
+                                       encoding="utf-8")
+    link = tmp_path / "link_to_outside"
+    os.symlink(target, link, target_is_directory=True)
+
+    # Dry run without follow-symlinks.
+    rc = run(["index", tmp_path, "--dry-run"])
+    assert rc == 0
+    _, err = capsys.readouterr()
+    assert "0 files" in err  # only the symlink dir, no real files found
+
+    # Dry run with --follow-symlinks.
+    rc = run(["index", tmp_path, "--follow-symlinks", "--dry-run"])
+    assert rc == 0
+    out, err = capsys.readouterr()
+    assert "1 file" in err
+    assert "outside.txt" in out


### PR DESCRIPTION
## Summary

Adds an opt-in `--follow-symlinks` flag to `whoosh index` that follows
symlinked directories when indexing (off by default for safety).

```console
# Without: symlinked directories are silently skipped
whoosh index ~/notes

# With: follow symlinks to index content behind them
whoosh index ~/notes --follow-symlinks
```

Closes #29.

## Changes

- **`iter_files()`** in `src/whoosh/cli.py`: accepts a new
  `follow_symlinks: bool = False` parameter and passes it through as
  `os.walk(root, followlinks=follow_symlinks)`.
- **`cmd_index()`**: passes `args.follow_symlinks` to both `iter_files()`
  calls (the `--dry-run` preview and the real indexing loop).
- **`build_parser()`**: adds `--follow-symlinks` action=\"store_true\"
  argument to the `index` subparser.
- **Tests** (`tests/test_cli.py`): two new tests verify that a symlinked
  directory outside the walk root is indexed with the flag and excluded
  without it. `--dry-run` also honors the flag.

## Verification

- [x] Existing tests pass (83/83)
- [x] New tests pass
- [x] No new dependencies
- [x] CLI-only change, no library API changes