### PR TITLE
feat(cli): add files-with-matches output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Added
+- CLI: `whoosh search -l` (alias `--files-with-matches`) prints one bare path
+  per matching result for shell pipelines, while respecting `--limit` and
+  `--page`. No matches produces no output and exits with status `1`.
+
 ## [3.20.0] - 2026-07-21
 
 ### Added

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -107,6 +107,7 @@ Useful options::
     $ whoosh search "index writer" ~/notes --snippet-chars 80  # shorter snippets
     $ whoosh search "index writer" ~/notes --json           # JSON array output
     $ whoosh search "index writer" ~/notes --jsonl          # JSON Lines output
+    $ whoosh search "index writer" ~/notes -l               # matching file paths only
     $ whoosh search "index writer" ~/notes --count          # output just the number of matches
     $ whoosh search "index writer" ~/notes --sort-by mtime  # newest files first
     $ whoosh search "index writer" ~/notes --field title    # search titles only
@@ -157,8 +158,17 @@ produces no output and exits with status ``1``::
 
     $ whoosh search "install guide" --jsonl | jq -c 'select(.score > 1.5)'
 
+``-l`` (alias ``--files-with-matches``) prints one bare matching file path per
+line, with no numbering, scores, snippets, or summary text. It respects
+``--limit`` and ``--page``, making it useful in shell pipelines such as::
+
+    $ whoosh search "index writer" ~/notes -l | xargs wc -l
+
+No matches produces no output and exits with status ``1``.
+
 The output-style flags (``--html``, ``--no-highlight``, ``--json``,
-``--jsonl``/``--ndjson`` and ``--count``) are mutually exclusive.
+``--jsonl``/``--ndjson``, ``-l``/``--files-with-matches`` and ``--count``) are
+mutually exclusive.
 
 ``--count`` prints only the total number of matching documents as a single integer
 and exits, which is great for shell pipelines. As an output-style flag, it

--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -283,9 +283,18 @@ def cmd_search(args: argparse.Namespace) -> int:
         if results.total and args.page > results.pagecount:
             if getattr(args, "json", False):
                 print(json.dumps([]))
-            elif not getattr(args, "jsonl", False):
+            elif not (
+                getattr(args, "jsonl", False)
+                or getattr(args, "files_with_matches", False)
+            ):
                 print(f"No matches for: {args.query!r}")
             return 1
+
+        if getattr(args, "files_with_matches", False):
+            paths = [hit["path"] for hit in results]
+            for path in paths:
+                print(path)
+            return 0 if paths else 1
 
         snippet_chars = getattr(args, "snippet_chars", 200)
         no_highlight = getattr(args, "no_highlight", False)
@@ -590,6 +599,9 @@ def build_parser() -> argparse.ArgumentParser:
                          "human-readable text")
     group.add_argument("--jsonl", "--ndjson", action="store_true",
                     help="emit newline-delimited JSON (one object per hit)")
+    group.add_argument("-l", "--files-with-matches", action="store_true",
+                    dest="files_with_matches",
+                    help="emit only matching file paths, one per line")
     group.add_argument("--count", action="store_true",
                     help="emit only the number of matching documents")
     ps.set_defaults(func=cmd_search)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -361,6 +361,50 @@ def test_search_count_ignores_page_and_reports_total(corpus, capsys):
     assert capsys.readouterr().out.strip() == "2"
 
 
+@pytest.mark.parametrize("flag", ["-l", "--files-with-matches"])
+def test_search_files_with_matches_prints_only_paths(corpus, capsys, flag):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+
+    assert run(["search", "search", corpus, flag]) == 0
+    out, err = capsys.readouterr()
+    assert set(out.splitlines()) == {"alpha.txt", "beta.md"}
+    assert "match" not in out.lower()
+    assert "score" not in out.lower()
+    assert err == ""
+
+
+def test_search_files_with_matches_honors_limit_and_page(corpus, capsys):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+
+    paths = []
+    for page in (1, 2):
+        assert run([
+            "search", "search", corpus, "-l", "--limit", "1",
+            "--page", str(page),
+        ]) == 0
+        paths.append(capsys.readouterr().out.strip())
+
+    assert set(paths) == {"alpha.txt", "beta.md"}
+
+
+def test_search_files_with_matches_no_matches_is_silent(corpus, capsys):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+
+    assert run(["search", "zzzznottherezzz", corpus, "-l"]) == 1
+    assert capsys.readouterr() == ("", "")
+
+
+@pytest.mark.parametrize(
+    "other", ["--json", "--jsonl", "--count", "--html", "--no-highlight"])
+def test_search_files_with_matches_is_mutually_exclusive(corpus, capsys, other):
+    with pytest.raises(SystemExit):
+        run(["search", "search", corpus, "-l", other])
+    assert "not allowed with argument" in capsys.readouterr().err.lower()
+
+
 def test_search_field_restricts_query(corpus, capsys):
     assert run(["index", corpus]) == 0
     capsys.readouterr()


### PR DESCRIPTION
## Summary

Add grep-style `-l` / `--files-with-matches` output to `whoosh search`, printing one bare matching file path per line for shell pipelines.

## Changes

- Add `-l` and `--files-with-matches` to the mutually exclusive search output modes.
- Print paths before highlighting and snippet setup, keeping output free of numbering, scores, snippets, and summaries.
- Preserve `--limit`, `--page`, and sorting behavior by rendering the existing result page.
- Return exit status 1 with no output when there are no matches or the requested page is out of range.
- Document the new mode and update the Unreleased changelog.
- Add regression coverage for both aliases, clean path output, pagination, no-match behavior, and output-mode exclusivity.

## Testing

- `python -m pytest -q`: 781 passed, 3 skipped
- `python -m pytest tests/test_cli.py -q`: 86 passed
- Changed-file Ruff check: passed
- Full-repository Ruff continues to report pre-existing baseline violations outside the changed files.

Fixes #36