### PR TITLE
feat(cli): add NUL-separated path output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Added
+- CLI: `whoosh search -l -0` (aliases `--files-with-matches --null`) emits
+  NUL-terminated paths for safe use with tools such as `xargs -0`.
+
 ## [3.21.0] - 2026-07-21
 
 ### Added

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -166,6 +166,15 @@ piping into other tools::
 
     $ whoosh search "index writer" ~/notes -l | xargs wc -l
 
+Use ``-0`` / ``--null`` with ``-l`` to terminate each path with a NUL byte
+instead of a newline. This safely handles spaces, newlines, and other unusual
+characters in file names when piping to tools that support NUL-separated
+input::
+
+    $ whoosh search "index writer" ~/notes -l -0 | xargs -0 wc -l
+
+``--null`` requires ``-l`` / ``--files-with-matches``.
+
 The output-style flags (``--html``, ``--no-highlight``, ``--json``,
 ``--jsonl``/``--ndjson``, ``--count`` and ``-l``/``--files-with-matches``) are
 mutually exclusive.

--- a/src/whoosh/cli.py
+++ b/src/whoosh/cli.py
@@ -233,6 +233,16 @@ def cmd_index(args: argparse.Namespace) -> int:
 
 
 def cmd_search(args: argparse.Namespace) -> int:
+    if (
+        getattr(args, "null", False)
+        and not getattr(args, "files_with_matches", False)
+    ):
+        print(
+            "whoosh search: error: --null requires --files-with-matches",
+            file=sys.stderr,
+        )
+        return 2
+
     root = os.path.abspath(args.directory)
     index_dir = os.path.join(root, INDEX_DIRNAME)
     if not index.exists_in(index_dir):
@@ -288,17 +298,20 @@ def cmd_search(args: argparse.Namespace) -> int:
         if results.total and args.page > results.pagecount:
             if getattr(args, "json", False):
                 print(json.dumps([]))
-            elif not getattr(args, "jsonl", False):
+            elif not (
+                getattr(args, "jsonl", False)
+                or getattr(args, "files_with_matches", False)
+            ):
                 print(f"No matches for: {args.query!r}")
             return 1
 
         # --files-with-matches: print bare file paths, one per hit.
         if getattr(args, "files_with_matches", False):
-            n = len(results)
-            if n == 0:
+            paths = [hit["path"] for hit in results]
+            if not paths:
                 return 1
-            for hit in results:
-                print(hit["path"])
+            separator = "\0" if getattr(args, "null", False) else "\n"
+            sys.stdout.write(separator.join(paths) + separator)
             return 0
 
         snippet_chars = getattr(args, "snippet_chars", 200)
@@ -590,6 +603,9 @@ def build_parser() -> argparse.ArgumentParser:
                     dest="sort_by",
                     help="sort results by relevance score (default) or "
                          "file modification time")
+    ps.add_argument("-0", "--null", action="store_true", dest="null",
+                    help="with -l, separate paths with a NUL byte instead of "
+                         "a newline (for xargs -0)")
 
     # Output style/mode flags are mutually exclusive: the default UPPERCASE
     # text, HTML highlights, a plain grep-friendly slice, machine-readable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -784,6 +784,40 @@ def test_search_files_with_matches_is_mutually_exclusive(corpus, capsys):
         assert "not allowed with argument" in err.lower()
 
 
+@pytest.mark.parametrize("flag", ["-0", "--null"])
+def test_search_null_separates_paths_with_trailing_nul(corpus, capsys, flag):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+
+    assert run(["search", "search", corpus, "-l", flag]) == 0
+    out, err = capsys.readouterr()
+    assert out.endswith("\0")
+    assert set(out.split("\0")[:-1]) == {"alpha.txt", "beta.md"}
+    assert "\n" not in out
+    assert err == ""
+
+
+def test_search_null_requires_files_with_matches(corpus, capsys):
+    assert run(["search", "search", corpus, "-0"]) == 2
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert "--null requires --files-with-matches" in err
+
+
+def test_search_null_no_matches_and_out_of_range_are_silent(corpus, capsys):
+    assert run(["index", corpus]) == 0
+    capsys.readouterr()
+
+    assert run(["search", "zzzznottherezzz", corpus, "-l", "-0"]) == 1
+    assert capsys.readouterr() == ("", "")
+
+    assert run([
+        "search", "search", corpus, "-l", "-0", "--limit", "1",
+        "--page", "3",
+    ]) == 1
+    assert capsys.readouterr() == ("", "")
+
+
 def test_index_follow_symlinks_includes_symlinked_directories(tmp_path, capsys):
     """--follow-symlinks indexes files reachable only through a symlink.
 


### PR DESCRIPTION
## Summary

Add `-0` / `--null` as a modifier for `whoosh search -l`, emitting NUL-terminated paths for safe shell pipelines such as `xargs -0`.

## Changes

- Add `-0` and `--null` to the search parser outside the mutually exclusive output-mode group.
- Return a clear exit status 2 error when `--null` is used without `-l` / `--files-with-matches`.
- Preserve newline-separated `-l` output while emitting a trailing NUL for every path in null mode.
- Keep no-match and out-of-range pages silent with exit status 1 in file-path output modes.
- Document the `xargs -0` workflow and update the Unreleased changelog.
- Add tests for both aliases, trailing NUL behavior, invalid usage, no matches, and out-of-range pages.

## Testing

- `python -m pytest -q`: 782 passed, 3 skipped
- Targeted `--null` tests: 4 passed
- Changed-file Ruff check: passed

Fixes #40