### PR TITLE
Type hints for whoosh.query.ranges and whoosh.query.positional (#55, #56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,26 @@ All notable changes to this project are documented here. This project follows
   only — runtime behaviour and docstrings are unchanged, and `Not`/
   `ConstantScoreQuery` are now exercised by the `tests/typing_smoke.py` mypy
   fixture. (#53)
+- Type hints for the public API of `whoosh.query.ranges` — the range query
+  classes `TermRange`, `NumericRange`, and `DateRange` (plus the shared
+  `RangeMixin`). These flow into editors and `mypy`/`pyright` through the
+  shipped `py.typed` marker: constructor arguments (`fieldname`, the
+  field-appropriate `start`/`end` bounds — `str` for `TermRange`, a number for
+  `NumericRange`, a `datetime` for `DateRange` — plus the `startexcl`/`endexcl`
+  flags, `boost`, and `constantscore`), the `is_range`/`overlaps` predicates,
+  `merge()` → `Query`, and the `repr`/`str`/`eq`/`hash` dunders. Annotations
+  only — runtime behaviour and docstrings are unchanged, and all three range
+  classes are now exercised by the `tests/typing_smoke.py` mypy fixture. (#55)
+- Type hints for the public API of `whoosh.query.positional` — the
+  position-aware query classes `Phrase`, `Sequence`, and `Ordered`. `Phrase`
+  is what quoted searches parse into, so its annotations flow into editors and
+  `mypy`/`pyright` through the shipped `py.typed` marker: constructor arguments
+  (`fieldname`, `words` as a `list[str]`, the wrapped `subqueries`, `slop`,
+  `ordered`, `boost`, and `char_ranges`), `has_terms()` → `bool`,
+  `terms()`/`tokens()` → their annotated iterators, `replace()` → `Phrase`, and
+  the `repr`/`str`/`eq`/`hash` dunders. Annotations only — runtime behaviour and
+  docstrings are unchanged, and `Phrase`/`Sequence`/`Ordered` are now exercised
+  by the `tests/typing_smoke.py` mypy fixture. (#56)
 
 ## [3.25.3] - 2026-07-24
 

--- a/src/whoosh/query/positional.py
+++ b/src/whoosh/query/positional.py
@@ -26,11 +26,17 @@
 # policies, either expressed or implied, of Matt Chaput.
 
 
+from __future__ import annotations
+
 import copy
+from typing import TYPE_CHECKING
 
 from whoosh import matching
 from whoosh.analysis import Token
 from whoosh.query import compound, qcore, terms
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class Sequence(compound.CompoundQuery):
@@ -44,7 +50,13 @@ class Sequence(compound.CompoundQuery):
     JOINT = " NEAR "
     intersect_merge = True
 
-    def __init__(self, subqueries, slop=1, ordered=True, boost=1.0):
+    def __init__(
+        self,
+        subqueries: list[qcore.Query],
+        slop: int = 1,
+        ordered: bool = True,
+        boost: float = 1.0,
+    ):
         """
         :param subqueries: a list of :class:`whoosh.query.Query` objects to
             match in sequence.
@@ -61,7 +73,7 @@ class Sequence(compound.CompoundQuery):
         self.slop = slop
         self.ordered = ordered
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (
             other
             and type(self) is type(other)
@@ -69,7 +81,7 @@ class Sequence(compound.CompoundQuery):
             and self.boost == other.boost
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "%s(%r, slop=%d, boost=%f)" % (
             self.__class__.__name__,
             self.subqueries,
@@ -77,7 +89,7 @@ class Sequence(compound.CompoundQuery):
             self.boost,
         )
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         h = hash(self.slop) ^ hash(self.boost)
         for q in self.subqueries:
             h ^= hash(q)
@@ -135,7 +147,13 @@ class Phrase(qcore.Query):
     """Matches documents containing a given phrase."""
 
     def __init__(
-        self, fieldname, words, slop=1, boost=1.0, char_ranges=None, degrade=False
+        self,
+        fieldname: str,
+        words: list[str],
+        slop: int = 1,
+        boost: float = 1.0,
+        char_ranges: list[tuple[int, int]] | None = None,
+        degrade: bool = False,
     ):
         """
         :param fieldname: the field to search.
@@ -174,7 +192,7 @@ class Phrase(qcore.Query):
         self.char_ranges = char_ranges
         self.degrade = degrade
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (
             other
             and self.__class__ is other.__class__
@@ -184,7 +202,7 @@ class Phrase(qcore.Query):
             and self.boost == other.boost
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "{}({!r}, {!r}, slop={}, boost={:f})".format(
             self.__class__.__name__,
             self.fieldname,
@@ -193,24 +211,24 @@ class Phrase(qcore.Query):
             self.boost,
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.fieldname}:\"{' '.join(self.words)}\""
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         h = hash(self.fieldname) ^ hash(self.slop) ^ hash(self.boost)
         for w in self.words:
             h ^= hash(w)
         return h
 
-    def has_terms(self):
+    def has_terms(self) -> bool:
         return True
 
-    def terms(self, phrases=False):
+    def terms(self, phrases: bool = False) -> Iterator[tuple[str, str]]:
         if phrases and self.field():
             for word in self.words:
                 yield (self.field(), word)
 
-    def tokens(self, boost=1.0):
+    def tokens(self, boost: float = 1.0) -> Iterator[Token]:
         char_ranges = self.char_ranges
         startchar = endchar = None
         for i, word in enumerate(self.words):
@@ -245,7 +263,7 @@ class Phrase(qcore.Query):
             degrade=self.degrade,
         )
 
-    def replace(self, fieldname, oldtext, newtext):
+    def replace(self, fieldname: str, oldtext: str, newtext: str) -> Phrase:
         q = copy.copy(self)
         if q.fieldname == fieldname:
             for i, word in enumerate(q.words):

--- a/src/whoosh/query/ranges.py
+++ b/src/whoosh/query/ranges.py
@@ -26,14 +26,21 @@
 # policies, either expressed or implied, of Matt Chaput.
 
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from whoosh.query import compound, qcore, terms, wrappers
 from whoosh.util.times import datetime_to_long
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class RangeMixin:
     # Contains methods shared by TermRange and NumericRange
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "{}({!r}, {!r}, {!r}, {}, {}, boost={}, constantscore={})".format(
             self.__class__.__name__,
             self.fieldname,
@@ -45,14 +52,14 @@ class RangeMixin:
             self.constantscore,
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         startchar = "{" if self.startexcl else "["
         endchar = "}" if self.endexcl else "]"
         start = "" if self.start is None else self.start
         end = "" if self.end is None else self.end
         return f"{self.fieldname}:{startchar}{start} TO {end}{endchar}"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (
             other
             and self.__class__ is other.__class__
@@ -65,7 +72,7 @@ class RangeMixin:
             and self.constantscore == other.constantscore
         )
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return (
             hash(self.fieldname)
             ^ hash(self.start)
@@ -75,7 +82,7 @@ class RangeMixin:
             ^ hash(self.boost)
         )
 
-    def is_range(self):
+    def is_range(self) -> bool:
         return True
 
     def _comparable_start(self):
@@ -92,7 +99,7 @@ class RangeMixin:
             second = -1 if self.endexcl else 0
             return (self.end, second)
 
-    def overlaps(self, other):
+    def overlaps(self, other: object) -> bool:
         if not isinstance(other, TermRange):
             return False
         if self.fieldname != other.fieldname:
@@ -110,7 +117,7 @@ class RangeMixin:
             or (end2 >= start1 and end2 <= end1)
         )
 
-    def merge(self, other, intersect=True):
+    def merge(self, other: RangeMixin, intersect: bool = True) -> qcore.Query:
         assert self.fieldname == other.fieldname
 
         start1 = self._comparable_start()
@@ -160,13 +167,13 @@ class TermRange(RangeMixin, terms.MultiTerm):
 
     def __init__(
         self,
-        fieldname,
-        start,
-        end,
-        startexcl=False,
-        endexcl=False,
-        boost=1.0,
-        constantscore=True,
+        fieldname: str,
+        start: str | None,
+        end: str | None,
+        startexcl: bool = False,
+        endexcl: bool = False,
+        boost: float = 1.0,
+        constantscore: bool = True,
     ):
         """
         :param fieldname: The name of the field to search.
@@ -294,13 +301,13 @@ class NumericRange(RangeMixin, qcore.Query):
 
     def __init__(
         self,
-        fieldname,
-        start,
-        end,
-        startexcl=False,
-        endexcl=False,
-        boost=1.0,
-        constantscore=True,
+        fieldname: str,
+        start: float | None,
+        end: float | None,
+        startexcl: bool = False,
+        endexcl: bool = False,
+        boost: float = 1.0,
+        constantscore: bool = True,
     ):
         """
         :param fieldname: The name of the field to search.
@@ -415,13 +422,13 @@ class DateRange(NumericRange):
 
     def __init__(
         self,
-        fieldname,
-        start,
-        end,
-        startexcl=False,
-        endexcl=False,
-        boost=1.0,
-        constantscore=True,
+        fieldname: str,
+        start: datetime | None,
+        end: datetime | None,
+        startexcl: bool = False,
+        endexcl: bool = False,
+        boost: float = 1.0,
+        constantscore: bool = True,
     ):
         self.startdate = start
         self.enddate = end
@@ -439,7 +446,7 @@ class DateRange(NumericRange):
             constantscore=constantscore,
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "{}({!r}, {!r}, {!r}, {}, {}, boost={})".format(
             self.__class__.__name__,
             self.fieldname,

--- a/tests/typing_smoke.py
+++ b/tests/typing_smoke.py
@@ -14,6 +14,7 @@ searching layer.
 from __future__ import annotations
 
 import tempfile
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from whoosh import highlight, index, scoring
@@ -23,12 +24,18 @@ from whoosh.query import (
     And,
     AndNot,
     ConstantScoreQuery,
+    DateRange,
     DisjunctionMax,
     FuzzyTerm,
     Not,
+    NumericRange,
     Or,
+    Ordered,
+    Phrase,
     Prefix,
+    Sequence,
     Term,
+    TermRange,
     Variations,
     Wildcard,
 )
@@ -204,6 +211,49 @@ def run() -> list[str]:
                 assert isinstance(child_label, str)
             wm: Matcher = wrapping_query.matcher(searcher)
             assert wm.is_active() in (True, False)
+
+        # Range query classes (whoosh.query.ranges): TermRange over a text
+        # field, and NumericRange/DateRange over the numeric/datetime fields.
+        # Their annotated constructors accept the documented start/end bounds
+        # (str for TermRange, a number for NumericRange, a datetime for
+        # DateRange) plus bool exclusivity flags and a float boost; str()
+        # returns str and matcher() keeps its Matcher return type.
+        term_range = TermRange("title", "a", "s", startexcl=False, endexcl=True)
+        numeric_range = NumericRange("views", 10, 5925, boost=1.5)
+        date_range = DateRange(
+            "created",
+            datetime(2010, 1, 1),
+            datetime(2010, 12, 31),
+            constantscore=True,
+        )
+        range_label: str = str(term_range)
+        assert isinstance(range_label, str)
+        overlaps: bool = term_range.overlaps(numeric_range)
+        assert overlaps in (True, False)
+        for range_query in (term_range, numeric_range, date_range):
+            rm: Matcher = range_query.matcher(searcher)
+            assert rm.is_active() in (True, False)
+
+        # Positional query classes (whoosh.query.positional): Phrase matches an
+        # ordered run of words, while Sequence/Ordered match sub-queries in
+        # adjacent positions. Their annotated constructors accept the documented
+        # words/subqueries plus int slop and float boost; str() returns str,
+        # terms()/tokens() yield their annotated element types, and matcher()
+        # keeps its Matcher return type.
+        phrase_q = Phrase("title", ["about", "search"], slop=1, boost=2.0)
+        seq_q = Sequence([term_q, prefix_q], slop=2, ordered=True)
+        ordered_q = Ordered([term_q, prefix_q], slop=2)
+        phrase_label: str = str(phrase_q)
+        assert isinstance(phrase_label, str)
+        for field_name, word in phrase_q.terms(phrases=True):
+            assert isinstance(field_name, str) and isinstance(word, str)
+        phrase_tokens: list[Any] = list(phrase_q.tokens())
+        assert isinstance(phrase_tokens, list)
+        pm: Matcher = phrase_q.matcher(searcher)
+        assert pm.is_active() in (True, False)
+        for positional_query in (seq_q, ordered_q):
+            positional_norm: Query = positional_query.normalize()
+            assert isinstance(repr(positional_norm), str)
     return titles
 
 


### PR DESCRIPTION
Completes the fully-typed `whoosh.query` package started in #52/#53.

Annotates the public API of:
- **`whoosh.query.ranges`** — `TermRange`, `NumericRange`, `DateRange` (and the shared `RangeMixin`): constructor bounds/flags, `is_range`/`overlaps`, `merge() -> Query`, and the repr/str/eq/hash dunders.
- **`whoosh.query.positional`** — `Phrase`, `Sequence`, `Ordered`: constructor args (`words: list[str]`, `subqueries`, `slop`, `ordered`, `boost`, `char_ranges`), `has_terms() -> bool`, `terms()`/`tokens()` iterators, `replace() -> Phrase`, and the dunders.

Annotations only — runtime behaviour and docstrings are unchanged. All three range classes plus `Phrase`/`Sequence`/`Ordered` are now exercised by the `tests/typing_smoke.py` mypy fixture, so CI guards them via the shipped `py.typed` marker.

Closes #55
Closes #56