### PR TITLE
Add runnable RAG / hybrid-search retriever example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Added
+- New example `examples/rag_retriever.py`: using Whoosh as a BM25 retriever for
+  RAG, with a runnable **hybrid search** pattern (Whoosh BM25 + any vector store,
+  fused via Reciprocal Rank Fusion). It demonstrates the complementary failure
+  modes hybrid search fixes — dense retrieval bridging synonyms while BM25 nails
+  rare literal tokens like error codes — and assembles the fused top-k chunks
+  into an LLM context window. Runs with only Whoosh and the standard library
+  (the dense retriever is a dependency-free stand-in you swap for
+  FAISS/Chroma/pgvector). Covered by `tests/test_example_rag_retriever.py` so
+  the "Whoosh for RAG" guide always has working code behind it.
+
 ## [3.26.0] - 2026-07-26
 
 This release completes the type annotations for the whole `whoosh.query`

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ reference (all flags, exit codes, and how it maps onto the API):
     — incremental sync, extract-text hooks, highlighted snippets
   - [Whoosh for RAG: BM25 keyword retrieval & hybrid search](https://priya-sundaram-dev.github.io/whoosh/whoosh-rag-hybrid-search.html)
     — pure-Python retrieval for LLM pipelines, no vector DB required
+    (runnable code: [`examples/rag_retriever.py`](examples/rag_retriever.py))
   - [Spelling, "did you mean?", and fuzzy search](https://priya-sundaram-dev.github.io/whoosh/whoosh-spelling-fuzzy-did-you-mean.html)
     — typo tolerance: suggestions, query correction, and fuzzy matching
 - **Docs site:** https://priya-sundaram-dev.github.io/whoosh/ (rebuilt; work in progress)
@@ -164,7 +165,9 @@ reference (all flags, exit codes, and how it maps onto the API):
   [Django](examples/django_app.py) (portable full-text search without
   PostgreSQL), and a
   [command-line folder-search tool](examples/search_cli.py) that indexes and
-  searches a directory of files in one command
+  searches a directory of files in one command, and a
+  [RAG / hybrid-search retriever](examples/rag_retriever.py) that pairs Whoosh
+  BM25 with any vector store via Reciprocal Rank Fusion
 - **Roadmap:** [ROADMAP.md](ROADMAP.md)
 - **Changelog:** [CHANGELOG.md](CHANGELOG.md)
 

--- a/examples/rag_retriever.py
+++ b/examples/rag_retriever.py
@@ -1,0 +1,198 @@
+"""
+Whoosh as a BM25 retriever for RAG (+ hybrid search)
+====================================================
+
+Retrieval-Augmented Generation lives or dies on retrieval: if the right chunk
+isn't in the model's context window, the model can't use it. Dense (vector)
+retrieval is great at *meaning* -- "car" matches "automobile" -- but it has a
+well-known blind spot: it can quietly fail on the *exact* tokens that matter
+most (product SKUs, function names, error codes like ``ERR_2043``, gene symbols,
+ticket IDs). Lexical BM25 is the classic complement: it rewards documents that
+contain the query's actual terms, weighted by rarity and length.
+
+Combining the two -- *hybrid search* -- reliably beats either one alone, because
+they fail on different queries. This example shows the whole pattern end to end,
+runnable with nothing but Whoosh and the standard library:
+
+  1. Index your chunks with Whoosh and retrieve with BM25 (`keyword_search`)
+  2. A *stand-in* dense retriever (`vector_search`) so the demo actually runs
+     with no vector DB, GPU, or embedding API -- swap in FAISS/Chroma/pgvector
+  3. Reciprocal Rank Fusion (`reciprocal_rank_fusion`) to merge the rankings
+  4. Assemble the fused top-k chunk text into an LLM context window
+
+Whoosh is a *lexical* engine -- it does not compute embeddings. That's the
+point: it handles the keyword half in pure Python (no server, no native wheels,
+the index is just a folder) so you can pair it with whatever vector store you
+already use.
+
+Run it:  python examples/rag_retriever.py
+
+Everything runs in memory (RamStorage) so there are no files to clean up.
+"""
+
+from whoosh import scoring
+from whoosh.fields import ID, TEXT, Schema
+from whoosh.filedb.filestore import RamStorage
+from whoosh.qparser import MultifieldParser, OrGroup
+
+# --------------------------------------------------------------------------
+# A tiny corpus of "chunks". In real RAG you split documents into passages and
+# store a stable `id` for each so you can join back to your vector store.
+# --------------------------------------------------------------------------
+CHUNKS = [
+    ("c1", "Routine car maintenance: check the engine oil, tyre pressure and brakes every few months."),
+    ("c2", "Python is a popular programming language for data science and machine learning."),
+    ("c3", "Cellular respiration converts glucose into ATP energy inside the mitochondria."),
+    ("c4", "Vector databases store embeddings so you can run semantic similarity search."),
+    ("c5", "Troubleshooting guide: error ERR_2043 means the payment gateway rejected the token."),
+    ("c6", "The mitochondria is often called the powerhouse of the cell."),
+]
+
+
+def build_index():
+    """Index the chunks in memory and return the Whoosh index."""
+    schema = Schema(
+        id=ID(stored=True, unique=True),
+        text=TEXT(stored=True),
+    )
+    ix = RamStorage().create_index(schema)
+    writer = ix.writer()
+    for chunk_id, text in CHUNKS:
+        writer.add_document(id=chunk_id, text=text)
+    writer.commit()
+    return ix
+
+
+def keyword_search(ix, query, k=10):
+    """Return up to k chunk ids ranked by Whoosh BM25 relevance.
+
+    Using an OrGroup parser keeps recall high: a chunk matches if it contains
+    *any* of the query terms, and BM25 still ranks the best-matching chunks
+    first (rewarding rarer, more discriminating terms).
+    """
+    with ix.searcher(weighting=scoring.BM25F()) as s:
+        parser = MultifieldParser(["text"], schema=ix.schema, group=OrGroup)
+        q = parser.parse(query)
+        return [hit["id"] for hit in s.search(q, limit=k)]
+
+
+# --------------------------------------------------------------------------
+# A STAND-IN dense retriever.
+#
+# Real dense retrieval would embed the query and search FAISS/Chroma/pgvector.
+# To keep this file dependency-free *and* to honestly demonstrate why hybrid
+# search wins, we fake "semantic" matching with a tiny concept lexicon: a query
+# concept matches a chunk if they share a concept, even when the surface words
+# differ ("automobile" -> the "car" chunk). Like a real embedding model, it is
+# good at meaning but blind to rare literal tokens it never learned (ERR_2043).
+# Swap this whole function for your production retriever; the interface is just
+# (query, k) -> list of chunk ids.
+# --------------------------------------------------------------------------
+_CONCEPTS = {
+    "c1": {"vehicle", "maintenance"},
+    "c2": {"programming", "ml"},
+    "c3": {"biology", "energy"},
+    "c4": {"vectors", "search"},
+    "c5": {"payments", "errors"},
+    "c6": {"biology"},
+}
+_QUERY_CONCEPTS = {
+    "automobile": {"vehicle"},
+    "car": {"vehicle"},
+    "vehicle": {"vehicle"},
+    "servicing": {"maintenance"},
+    "maintenance": {"maintenance"},
+    "coding": {"programming"},
+    "energy": {"energy"},
+    "powerhouse": {"energy", "biology"},
+    "cell": {"biology"},
+    "payment": {"payments"},
+    "embeddings": {"vectors"},
+}
+
+
+def vector_search(query, k=10):
+    """Stand-in for a real embedding retriever: concept-overlap similarity."""
+    q_concepts = set()
+    for word in query.lower().split():
+        q_concepts |= _QUERY_CONCEPTS.get(word.strip(".,?!"), set())
+    scored = []
+    for chunk_id, concepts in _CONCEPTS.items():
+        overlap = len(q_concepts & concepts)
+        if overlap:
+            scored.append((overlap, chunk_id))
+    scored.sort(reverse=True)
+    return [chunk_id for _, chunk_id in scored[:k]]
+
+
+def reciprocal_rank_fusion(rankings, k=60):
+    """Fuse several ranked id-lists into one.
+
+    RRF scores each id by ``1 / (k + rank)`` summed across every ranking it
+    appears in, so an id ranked highly by *either* retriever floats to the top
+    and ids found by *both* win outright. ``k=60`` is the standard constant;
+    it damps the influence of any single list's exact positions.
+    """
+    scores = {}
+    for ranking in rankings:
+        for rank, doc_id in enumerate(ranking):
+            scores[doc_id] = scores.get(doc_id, 0.0) + 1.0 / (k + rank + 1)
+    return sorted(scores, key=scores.get, reverse=True)
+
+
+def hybrid_search(ix, query, k=10):
+    """Combine Whoosh BM25 with the (stand-in) dense retriever via RRF."""
+    lexical = keyword_search(ix, query, k=k)
+    dense = vector_search(query, k=k)
+    return reciprocal_rank_fusion([lexical, dense])[:k]
+
+
+def build_context(ix, chunk_ids):
+    """Fetch chunk text back for the LLM context window, in ranked order."""
+    with ix.searcher() as s:
+        texts = []
+        for cid in chunk_ids:
+            doc = s.document(id=cid)
+            if doc:
+                texts.append(doc["text"])
+        return "\n\n".join(texts)
+
+
+def _demo():
+    ix = build_index()
+
+    print("=" * 70)
+    print("Why hybrid beats either retriever alone")
+    print("=" * 70)
+
+    # 1) A synonym query: the user says "automobile", the chunk says "car".
+    #    BM25 has no literal term to match; the dense stand-in bridges meaning.
+    q1 = "automobile servicing"
+    print(f"\nQuery: {q1!r}")
+    print(f"  BM25 (lexical): {keyword_search(ix, q1)}   <- misses c1 (no word 'automobile')")
+    print(f"  Dense (stand-in): {vector_search(q1)}   <- bridges 'automobile' -> car chunk")
+    print(f"  Hybrid (RRF):   {hybrid_search(ix, q1)}   <- recovers c1")
+
+    # 2) A rare literal token: an error code the embedding model never learned.
+    #    Dense misses it; BM25 nails it because the exact token is rare.
+    q2 = "ERR_2043 rejected token"
+    print(f"\nQuery: {q2!r}")
+    print(f"  BM25 (lexical): {keyword_search(ix, q2)}   <- nails c5 on the exact code")
+    print(f"  Dense (stand-in): {vector_search(q2)}   <- misses: no concept for a rare code")
+    print(f"  Hybrid (RRF):   {hybrid_search(ix, q2)}   <- keeps c5 on top")
+
+    # 3) Assemble a context window for the LLM from the fused top-k.
+    print("\n" + "=" * 70)
+    print("Assembling an LLM context window from the fused top-k")
+    print("=" * 70)
+    q3 = "energy in the mitochondria"
+    ids = hybrid_search(ix, q3, k=3)
+    print(f"\nQuery: {q3!r}  ->  fused ids: {ids}")
+    context = build_context(ix, ids)
+    print("\n--- context passed to the model ---")
+    print(context)
+    print("--- end context ---")
+
+
+if __name__ == "__main__":
+    _demo()

--- a/tests/test_example_rag_retriever.py
+++ b/tests/test_example_rag_retriever.py
@@ -1,0 +1,57 @@
+"""Smoke tests for examples/rag_retriever.py.
+
+These keep the RAG / hybrid-search example (referenced from the README and the
+"Whoosh for RAG" guide) runnable, so the marketing claim always has working
+code behind it.
+"""
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_EXAMPLE = pathlib.Path(__file__).resolve().parent.parent / "examples" / "rag_retriever.py"
+
+
+@pytest.fixture(scope="module")
+def rag():
+    spec = importlib.util.spec_from_file_location("rag_retriever", _EXAMPLE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_keyword_search_ranks_exact_terms(rag):
+    ix = rag.build_index()
+    # A rare literal token (an error code) must be found by BM25.
+    assert rag.keyword_search(ix, "ERR_2043 rejected token")[0] == "c5"
+
+
+def test_dense_bridges_synonyms_but_misses_rare_tokens(rag):
+    # The stand-in dense retriever bridges "automobile" -> the "car" chunk...
+    assert "c1" in rag.vector_search("automobile servicing")
+    # ...but has no concept for a rare literal code.
+    assert rag.vector_search("ERR_2043 rejected token") == []
+
+
+def test_hybrid_recovers_both_failure_modes(rag):
+    ix = rag.build_index()
+    # BM25 alone misses the synonym query; hybrid recovers it.
+    assert rag.keyword_search(ix, "automobile servicing") == []
+    assert "c1" in rag.hybrid_search(ix, "automobile servicing")
+    # Dense alone misses the rare code; hybrid keeps it.
+    assert "c5" in rag.hybrid_search(ix, "ERR_2043 rejected token")
+
+
+def test_rrf_prefers_ids_found_by_both(rag):
+    fused = rag.reciprocal_rank_fusion([["a", "b", "c"], ["b", "d"]])
+    # "b" appears in both lists, so it should rank first.
+    assert fused[0] == "b"
+
+
+def test_build_context_joins_chunk_text(rag):
+    ix = rag.build_index()
+    ids = rag.hybrid_search(ix, "energy in the mitochondria", k=3)
+    context = rag.build_context(ix, ids)
+    assert "mitochondria" in context
+    assert context.count("\n\n") == len(ids) - 1


### PR DESCRIPTION
Adds `examples/rag_retriever.py`: Whoosh as a BM25 retriever for RAG plus a runnable **hybrid search** pattern (Whoosh BM25 + any vector store, fused via Reciprocal Rank Fusion).

- Demonstrates the complementary failure modes hybrid search fixes: the dense stand-in bridges synonyms (automobile -> car chunk) while BM25 nails rare literal tokens (error codes like ERR_2043).
- Assembles the fused top-k chunks into an LLM context window.
- Runs with only Whoosh + the standard library; the dense retriever is a dependency-free stand-in you swap for FAISS/Chroma/pgvector.
- Covered by `tests/test_example_rag_retriever.py` so the *Whoosh for RAG* guide always has working code behind it.
- Wired into README (Guides + Examples) and CHANGELOG.