### PR TITLE
types(writing): annotate IndexWriter public write API (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project are documented here. This project follows
 ## [Unreleased]
 
 ### Added
+- Type hints for the public write API in `whoosh.writing` — the `IndexWriter`
+  surface almost every Whoosh program calls. The schema-mutation helpers
+  (`add_field(name, FieldType)` / `remove_field(name)` → `None`), the deletion
+  helpers (`delete_by_term()` / `delete_by_query()` → `int` count of documents
+  removed, `delete_document(docnum)`), and the grouping helpers
+  (`group()` → context manager, `start_group()` / `end_group()`) now carry
+  [PEP 484](https://peps.python.org/pep-0484/) annotations, alongside the
+  already-typed `add_document` / `update_document` / `commit` / `cancel`. Heavy
+  imports (`Query`, `FieldType`, `IndexReader`, `Searcher`) stay under
+  `TYPE_CHECKING` and the module gains `from __future__ import annotations`, so
+  there is no import-time cost. The writer entry points are now exercised by the
+  `tests/typing_smoke.py` mypy fixture. Annotations only — no runtime behaviour
+  changes. (#62)
 - Type hints for the public API of `whoosh.spelling` — the spell-correction /
   "did you mean" surface. `Corrector.suggest()` (and the `_suggestions()` hook
   subclasses override), `ReaderCorrector` / `ListCorrector` / `MultiCorrector`,

--- a/src/whoosh/writing.py
+++ b/src/whoosh/writing.py
@@ -42,12 +42,14 @@ groups many small updates into periodic commits, and
 the index is locked.
 """
 
+from __future__ import annotations
+
 import threading
 import time
 from abc import abstractmethod
 from bisect import bisect_right
-from contextlib import contextmanager
-from typing import Any
+from contextlib import AbstractContextManager, contextmanager
+from typing import TYPE_CHECKING, Any
 
 from whoosh import columns
 from whoosh.externalsort import SortingPool
@@ -56,6 +58,12 @@ from whoosh.index import LockError
 from whoosh.util import fib, random_name
 from whoosh.util.filelock import try_for
 from whoosh.util.text import utf8encode
+
+if TYPE_CHECKING:
+    from whoosh.fields import FieldType
+    from whoosh.query import Query
+    from whoosh.reading import IndexReader
+    from whoosh.searching import Searcher
 
 # Exceptions
 
@@ -235,7 +243,7 @@ class IndexWriter:
     ...     w.add_document(title="Second document", content="This is easy!")
     """
 
-    def __enter__(self) -> "IndexWriter":
+    def __enter__(self) -> IndexWriter:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -244,7 +252,7 @@ class IndexWriter:
         else:
             self.commit()
 
-    def group(self):
+    def group(self) -> AbstractContextManager[None]:
         """Returns a context manager that calls
         :meth:`~IndexWriter.start_group` and :meth:`~IndexWriter.end_group` for
         you, allowing you to use a ``with`` statement to group hierarchical
@@ -267,7 +275,7 @@ class IndexWriter:
 
         return groupmanager(self)
 
-    def start_group(self):
+    def start_group(self) -> None:
         """Start indexing a group of hierarchical documents. The backend should
         ensure that these documents are all added to the same segment::
 
@@ -293,14 +301,14 @@ class IndexWriter:
 
         pass
 
-    def end_group(self):
+    def end_group(self) -> None:
         """Finish indexing a group of hierarchical documents. See
         :meth:`~IndexWriter.start_group`.
         """
 
         pass
 
-    def add_field(self, fieldname, fieldtype, **kwargs):
+    def add_field(self, fieldname: str, fieldtype: FieldType, **kwargs: Any) -> None:
         """Adds a field to the index's schema.
 
         :param fieldname: the name of the field to add.
@@ -310,7 +318,7 @@ class IndexWriter:
 
         self.schema.add(fieldname, fieldtype, **kwargs)
 
-    def remove_field(self, fieldname, **kwargs):
+    def remove_field(self, fieldname: str, **kwargs: Any) -> None:
         """Removes the named field from the index's schema. Depending on the
         backend implementation, this may or may not actually remove existing
         data for the field from the index. Optimizing the index should always
@@ -320,17 +328,19 @@ class IndexWriter:
         self.schema.remove(fieldname, **kwargs)
 
     @abstractmethod
-    def reader(self, **kwargs):
+    def reader(self, **kwargs: Any) -> IndexReader:
         """Returns a reader for the existing index."""
 
         raise NotImplementedError
 
-    def searcher(self, **kwargs):
+    def searcher(self, **kwargs: Any) -> Searcher:
         from whoosh.searching import Searcher
 
         return Searcher(self.reader(), **kwargs)
 
-    def delete_by_term(self, fieldname, text, searcher=None):
+    def delete_by_term(
+        self, fieldname: str, text: str, searcher: Searcher | None = None
+    ) -> int:
         """Deletes any documents containing "term" in the "fieldname" field.
         This is useful when you have an indexed field containing a unique ID
         (such as "pathname") for each document.
@@ -343,7 +353,7 @@ class IndexWriter:
         q = Term(fieldname, text)
         return self.delete_by_query(q, searcher=searcher)
 
-    def delete_by_query(self, q, searcher=None):
+    def delete_by_query(self, q: Query, searcher: Searcher | None = None) -> int:
         """Deletes any documents matching a query object.
 
         :returns: the number of documents deleted.
@@ -366,7 +376,7 @@ class IndexWriter:
         return count
 
     @abstractmethod
-    def delete_document(self, docnum, delete=True):
+    def delete_document(self, docnum: int, delete: bool = True) -> None:
         """Deletes a document by number."""
         raise NotImplementedError
 

--- a/tests/typing_smoke.py
+++ b/tests/typing_smoke.py
@@ -77,6 +77,30 @@ def run() -> list[str]:
         w.add_document(id="2", title="Second document about indexing")
         w.update_document(id="2", title="Second document about indexing v2")
 
+    # whoosh.writing's IndexWriter public API is annotated (gh#62). Exercise
+    # the schema-mutation, deletion and grouping helpers on a throwaway index
+    # so their side effects don't perturb the search fixture below. The precise
+    # types flow into user code: add_field/remove_field return ``None``, the
+    # delete_by_* helpers return the deleted-document ``int`` count, and
+    # group() yields an AbstractContextManager usable in a ``with`` statement.
+    wtmp = tempfile.mkdtemp()
+    wix = index.create_in(wtmp, build_schema())
+    w2: IndexWriter = wix.writer()
+    w2.add_field("body", TEXT(stored=True))
+    with w2.group():
+        w2.add_document(id="10", title="Grouped parent", body="child text")
+        w2.add_document(id="11", title="Grouped child", body="more text")
+    deleted_by_term: int = w2.delete_by_term("id", "10")
+    deleted_by_query: int = w2.delete_by_query(Term("id", "11"))
+    assert deleted_by_term >= 0 and deleted_by_query >= 0
+    w2.commit()
+
+    # remove_field is applied on a fresh writer (schema edits must precede any
+    # buffered documents); its ``-> None`` annotation flows here too.
+    w3: IndexWriter = wix.writer()
+    w3.remove_field("body")
+    w3.commit()
+
     # The scoring public API is annotated, so tuning constructors and the
     # WeightingModel/BaseScorer surface type-check for downstream users.
     weighting: scoring.WeightingModel = scoring.BM25F(B=0.75, K1=1.2)


### PR DESCRIPTION
## Summary

Adds PEP 484 type hints to the public write API in `whoosh.writing` — the
`IndexWriter` surface almost every Whoosh program touches. Closes #62 and
continues the incremental typing effort (after `whoosh.classify` #60,
`whoosh.spelling` #61).

## What's annotated

Base `IndexWriter` public contract:

- `add_field(fieldname: str, fieldtype: FieldType, **kwargs) -> None`
- `remove_field(fieldname: str, **kwargs) -> None`
- `delete_by_term(fieldname: str, text: str, searcher=None) -> int`
- `delete_by_query(q: Query, searcher=None) -> int`
- `delete_document(docnum: int, delete: bool = True) -> None`
- `group() -> AbstractContextManager[None]`, `start_group() -> None`, `end_group() -> None`
- `reader(**kwargs) -> IndexReader`, `searcher(**kwargs) -> Searcher`
- de-quoted the now-lazy `__enter__(self) -> IndexWriter` annotation

These join the already-typed `add_document` / `update_document` / `commit` /
`cancel`. Subclass overrides (`SegmentWriter` / `AsyncWriter` / `BufferedWriter`)
are left for a follow-up per the issue scope.

## House style

- `from __future__ import annotations` at the top so annotations stay lazy.
- Heavy/circular imports (`Query`, `FieldType`, `IndexReader`, `Searcher`) under
  `if TYPE_CHECKING:`, mirroring `whoosh.classify` / `whoosh.spelling`.
- **Annotation only** — no runtime behaviour or docstring changes.

## Tests

`tests/typing_smoke.py` now exercises the writer API (add_field, grouped
add_document, delete_by_term/delete_by_query return-`int`, remove_field) on a
throwaway index so it doesn't perturb the search fixture.

## Verification

- `mypy` smoke fixture: **Success, no issues**
- `ruff check src/whoosh/writing.py tests/typing_smoke.py`: no new findings
- `pytest -q tests/test_writing.py`: **27 passed**
- full suite: **809 passed**