### PR TITLE
release: 3.29.0 (complete public-API type hints)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+## [3.29.0] - 2026-07-28
+
 ### Added
 - Type hints for the public read API in `whoosh.reading` — the `IndexReader`
   surface every search touches. The term-enumeration methods

--- a/demo/index.html
+++ b/demo/index.html
@@ -32,7 +32,7 @@
   "url": "https://priya-sundaram-dev.github.io/whoosh/",
   "downloadUrl": "https://pypi.org/project/whoosh3/",
   "codeRepository": "https://github.com/priya-sundaram-dev/whoosh",
-  "softwareVersion": "3.28.0",
+  "softwareVersion": "3.29.0",
   "license": "https://github.com/priya-sundaram-dev/whoosh/blob/main/LICENSE.txt",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
   "keywords": "full-text search, pure python search, BM25, indexing, information retrieval, whoosh, Flask search, Django search, SQLite FTS alternative",

--- a/demo/is-whoosh-still-maintained.html
+++ b/demo/is-whoosh-still-maintained.html
@@ -148,7 +148,7 @@
       existing on-disk indexes keep working;</li>
     <li>ships tagged releases to PyPI with a
       <a href="https://github.com/priya-sundaram-dev/whoosh/blob/main/CHANGELOG.md">changelog</a>
-      &mdash; the latest is <strong>whoosh3&nbsp;3.28.0</strong> (July&nbsp;2026),
+      &mdash; the latest is <strong>whoosh3&nbsp;3.29.0</strong> (July&nbsp;2026),
       one of a steady run of bug-fix and feature releases shipped this month;</li>
     <li>has a public issue tracker with labeled
       <a href="https://github.com/priya-sundaram-dev/whoosh/issues">good-first-issues</a>

--- a/src/whoosh/__init__.py
+++ b/src/whoosh/__init__.py
@@ -27,7 +27,7 @@
 
 from typing import Tuple
 
-__version__: Tuple[int, ...] = (3, 28, 0)
+__version__: Tuple[int, ...] = (3, 29, 0)
 #: String form of :data:`__version__`, kept in sync automatically so the two
 #: can never drift. Used as the single source of truth for the packaged version
 #: (see ``pyproject.toml``'s ``version = { attr = "whoosh.__version_str__" }``).


### PR DESCRIPTION
Cut **whoosh3 3.29.0**.

This release completes the PEP 484 typing effort across Whoosh's core public modules. With `whoosh.reading` (#64), `whoosh.writing` (#62), and `whoosh.spelling` (#61) now annotated — alongside the already-typed `whoosh.query`, `whoosh.fields`, `whoosh.scoring`, and `whoosh.classify` (#60) — the shipped `py.typed` marker gives downstream users real signatures for the full read / write / search / spell surface in their editors and `mypy`/`pyright` runs.

## Contents
- Version bumped to `3.29.0` in `src/whoosh/__init__.py` (single source of truth) and the `demo/` site pages, via `scripts/bump_version.py` so the release lands green in one commit (`tests/test_site_version_sync.py` stays satisfied).
- `CHANGELOG.md` `[Unreleased]` rolled into `## [3.29.0]` with the three typing entries (reading, writing, spelling).

Annotation-only across the board — **no runtime behaviour changes**.

After this merges I will tag `v3.29.0` and publish to PyPI.
