### PR TITLE
Add type hints to whoosh.analysis.ngrams (gh#71)

### DIFF
--- a/src/whoosh/analysis/ngrams.py
+++ b/src/whoosh/analysis/ngrams.py
@@ -69,7 +69,7 @@ class NgramTokenizer(Tokenizer):
         self.min = minsize
         self.max = maxsize or minsize
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if self.__class__ is other.__class__:
             if self.min == other.min and self.max == other.max:
                 return True
@@ -165,7 +165,7 @@ class NgramFilter(Filter):
         elif at == "end":
             self.at = 1
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         return (
             other
             and self.__class__ is other.__class__

--- a/src/whoosh/analysis/ngrams.py
+++ b/src/whoosh/analysis/ngrams.py
@@ -25,9 +25,18 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from whoosh.analysis.acore import Token
 from whoosh.analysis.filters import Filter, LowercaseFilter
 from whoosh.analysis.tokenizers import RegexTokenizer, Tokenizer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+    from whoosh.analysis.analyzers import CompositeAnalyzer
 
 # Tokenizer
 
@@ -50,7 +59,7 @@ class NgramTokenizer(Tokenizer):
 
     __inittypes__ = {"minsize": int, "maxsize": int}
 
-    def __init__(self, minsize, maxsize=None):
+    def __init__(self, minsize: int, maxsize: int | None = None) -> None:
         """
         :param minsize: The minimum size of the N-grams.
         :param maxsize: The maximum size of the N-grams. If you omit
@@ -60,7 +69,7 @@ class NgramTokenizer(Tokenizer):
         self.min = minsize
         self.max = maxsize or minsize
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if self.__class__ is other.__class__:
             if self.min == other.min and self.max == other.max:
                 return True
@@ -68,16 +77,16 @@ class NgramTokenizer(Tokenizer):
 
     def __call__(
         self,
-        value,
-        positions=False,
-        chars=False,
-        keeporiginal=False,
-        removestops=True,
-        start_pos=0,
-        start_char=0,
-        mode="",
-        **kwargs,
-    ):
+        value: str,
+        positions: bool = False,
+        chars: bool = False,
+        keeporiginal: bool = False,
+        removestops: bool = True,
+        start_pos: int = 0,
+        start_char: int = 0,
+        mode: str = "",
+        **kwargs: Any,
+    ) -> Iterator[Token]:
         assert isinstance(value, str), f"{value!r} is not unicode"
 
         inlen = len(value)
@@ -136,7 +145,9 @@ class NgramFilter(Filter):
 
     __inittypes__ = {"minsize": int, "maxsize": int}
 
-    def __init__(self, minsize, maxsize=None, at=None):
+    def __init__(
+        self, minsize: int, maxsize: int | None = None, at: str | None = None
+    ) -> None:
         """
         :param minsize: The minimum size of the N-grams.
         :param maxsize: The maximum size of the N-grams. If you omit this
@@ -154,7 +165,7 @@ class NgramFilter(Filter):
         elif at == "end":
             self.at = 1
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         return (
             other
             and self.__class__ is other.__class__
@@ -162,7 +173,7 @@ class NgramFilter(Filter):
             and self.max == other.max
         )
 
-    def __call__(self, tokens):
+    def __call__(self, tokens: Iterable[Token]) -> Iterator[Token]:
         assert hasattr(tokens, "__iter__")
         at = self.at
         for t in tokens:
@@ -233,7 +244,7 @@ class NgramFilter(Filter):
 # Analyzers
 
 
-def NgramAnalyzer(minsize, maxsize=None):
+def NgramAnalyzer(minsize: int, maxsize: int | None = None) -> CompositeAnalyzer:
     """Composes an NgramTokenizer and a LowercaseFilter.
 
     >>> ana = NgramAnalyzer(4)
@@ -244,7 +255,12 @@ def NgramAnalyzer(minsize, maxsize=None):
     return NgramTokenizer(minsize, maxsize=maxsize) | LowercaseFilter()
 
 
-def NgramWordAnalyzer(minsize, maxsize=None, tokenizer=None, at=None):
+def NgramWordAnalyzer(
+    minsize: int,
+    maxsize: int | None = None,
+    tokenizer: Tokenizer | None = None,
+    at: str | None = None,
+) -> CompositeAnalyzer:
     if not tokenizer:
         tokenizer = RegexTokenizer()
     return tokenizer | LowercaseFilter() | NgramFilter(minsize, maxsize, at=at)

--- a/tests/typing_smoke.py
+++ b/tests/typing_smoke.py
@@ -19,6 +19,14 @@ from operator import add
 from typing import TYPE_CHECKING, Any
 
 from whoosh import classify, highlight, index, scoring, spelling
+from whoosh.analysis.acore import Token
+from whoosh.analysis.ngrams import (
+    NgramAnalyzer,
+    NgramFilter,
+    NgramTokenizer,
+    NgramWordAnalyzer,
+)
+from whoosh.analysis.tokenizers import RegexTokenizer
 from whoosh.fields import DATETIME, ID, NUMERIC, TEXT, Schema
 from whoosh.qparser import QueryParser
 from whoosh.query import (
@@ -42,6 +50,9 @@ from whoosh.query import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from whoosh.analysis.analyzers import CompositeAnalyzer
     from whoosh.matching import Matcher
     from whoosh.query import Query
     from whoosh.reading import IndexReader, TermInfo
@@ -444,6 +455,25 @@ def run() -> list[str]:
 
         term_leaves, phrase_leaves = phrase_q.phrases()
         assert isinstance(term_leaves, list) and isinstance(phrase_leaves, list)
+
+    # whoosh.analysis.ngrams public API (gh#71): the N-gram tokenizer/filter
+    # pair behind autocomplete and prefix search. The annotations flow the
+    # concrete types into user code: the constructors take ``int`` sizes and an
+    # optional ``at`` string, calling the tokenizer or the filter yields
+    # ``Token`` objects, and the analyzer factories return a composed analyzer.
+    ngram_tokenizer = NgramTokenizer(2, 3)
+    ngram_tokens: list[Token] = list(ngram_tokenizer("hi there", positions=True))
+    assert all(isinstance(tok, Token) for tok in ngram_tokens)
+
+    ngram_filter = NgramFilter(2, 4, at="start")
+    filtered: Iterator[Token] = ngram_filter(RegexTokenizer()("hello there"))
+    assert all(isinstance(tok, Token) for tok in filtered)
+
+    ngram_analyzer: CompositeAnalyzer = NgramAnalyzer(3)
+    word_analyzer: CompositeAnalyzer = NgramWordAnalyzer(2, 4, at="end")
+    gram_texts: list[str] = [str(tok.text) for tok in ngram_analyzer("hi there")]
+    word_texts: list[str] = [str(tok.text) for tok in word_analyzer("hello there")]
+    assert gram_texts and word_texts
 
     return titles
 


### PR DESCRIPTION
## Summary
​
Annotates the public API of `whoosh/analysis/ngrams.py` and exercises it from
`tests/typing_smoke.py`, following the earlier slices in gh#3.
​
- `NgramTokenizer` / `NgramFilter`: `minsize: int`, `maxsize: int | None`,
  `at: str | None`; both `__call__`s are generators, so both return
  `Iterator[Token]`.
- `NgramAnalyzer` / `NgramWordAnalyzer` return `CompositeAnalyzer`.
- Added `from __future__ import annotations` for the 3.9 floor. `Iterable`,
  `Iterator` and `CompositeAnalyzer` sit under `if TYPE_CHECKING:` —
  `CompositeAnalyzer` must, since `analysis.analyzers` imports back into this
  module.
- `__eq__` takes `object` rather than `Any` (PYI032).
​
Annotations only — no runtime behaviour or docstring changes.
​
```
$ python -m mypy
Success: no issues found in 1 source file
​
$ ruff check src/whoosh/analysis/ngrams.py
All checks passed!
```
​
Two notes:
​
1. `NgramFilter.__eq__` is annotated `-> bool` but returns `None` when `other`
   is `None` (`return other and ...`). Typed `bool` to match the supertype;
   fixing it would be a behaviour change. Same pattern in `Tokenizer.__eq__`.
   Happy to do both in a separate PR.
2. `CHANGELOG.md` untouched — not user-facing. Say the word and I'll add an
   entry.
​
First time contributing here. I set up the env, ran
the checks and reviewed the diff before opening this.
​
## Related issues
Closes #71
Part of #3
​
## Checklist
- [x] Tests pass locally (`pytest tests/`)
- [x] Added/updated tests for the change where it makes sense
- [x] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
​