### PR TITLE
typing: add PEP 484 annotations to whoosh.analysis.tokenizers (#72)

### DIFF
--- a/src/whoosh/analysis/tokenizers.py
+++ b/src/whoosh/analysis/tokenizers.py
@@ -31,6 +31,9 @@ import re
 import unicodedata
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from whoosh.analysis.analyzers import CompositeAnalyzer
 
 from whoosh.analysis.acore import Composable, Token
 from whoosh.util.text import rcompile
@@ -405,7 +408,7 @@ def SpaceSeparatedTokenizer() -> RegexTokenizer:
     return RegexTokenizer(r"[^ \t\r\n]+")
 
 
-def CommaSeparatedTokenizer() -> Composable:
+def CommaSeparatedTokenizer() -> CompositeAnalyzer:
     """Splits tokens by commas.
 
     Note that the tokenizer calls unicode.strip() on each match of the regular

--- a/src/whoosh/analysis/tokenizers.py
+++ b/src/whoosh/analysis/tokenizers.py
@@ -81,6 +81,7 @@ class IDTokenizer(Tokenizer):
         yield t
 
 
+default_pattern = re.compile(r"[\w\*]+(\.?[\w\*]+)*")
 class RegexTokenizer(Tokenizer):
     """
     Uses a regular expression to extract tokens from text.

--- a/src/whoosh/analysis/tokenizers.py
+++ b/src/whoosh/analysis/tokenizers.py
@@ -25,12 +25,15 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
+from __future__ import annotations
+
+import re
 import unicodedata
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
 
 from whoosh.analysis.acore import Composable, Token
 from whoosh.util.text import rcompile
-
-default_pattern = rcompile(r"[\w\*]+(\.?[\w\*]+)*")
 
 
 # Tokenizers
@@ -54,16 +57,16 @@ class IDTokenizer(Tokenizer):
 
     def __call__(
         self,
-        value,
-        positions=False,
-        chars=False,
-        keeporiginal=False,
-        removestops=True,
-        start_pos=0,
-        start_char=0,
-        mode="",
-        **kwargs,
-    ):
+        value: str,
+        positions: bool = False,
+        chars: bool = False,
+        keeporiginal: bool = False,
+        removestops: bool = True,
+        start_pos: int = 0,
+        start_char: int = 0,
+        mode: str = "",
+        **kwargs: Any,
+    ) -> Iterator[Token]:
         assert isinstance(value, str), f"{value!r} is not unicode"
         t = Token(positions, chars, removestops=removestops, mode=mode, **kwargs)
         t.text = value
@@ -87,7 +90,7 @@ class RegexTokenizer(Tokenizer):
     ["hi", "there", "3.141", "big", "time", "under_score"]
     """
 
-    def __init__(self, expression=default_pattern, gaps=False):
+    def __init__(self, expression: str | re.Pattern[str] = default_pattern, gaps: bool = False,):
         """
         :param expression: A regular expression object or string. Each match
             of the expression equals a token. Group 0 (the entire matched text)
@@ -108,17 +111,18 @@ class RegexTokenizer(Tokenizer):
 
     def __call__(
         self,
-        value,
-        positions=False,
-        chars=False,
-        keeporiginal=False,
-        removestops=True,
-        start_pos=0,
-        start_char=0,
-        tokenize=True,
-        mode="",
-        **kwargs,
-    ):
+        value: str,
+        positions: bool = False,
+        chars: bool = False,
+        keeporiginal: bool = False,
+        removestops: bool = True,
+        start_pos: int = 0,
+        start_char: int = 0,
+        tokenize: bool = True,
+        mode: str = "",
+        **kwargs: Any,
+    ) -> Iterator[Token]:
+
         """
         :param value: The unicode string to tokenize.
         :param positions: Whether to record token positions in the token.
@@ -242,7 +246,7 @@ class NormalizingRegexTokenizer(RegexTokenizer):
         does not affect matching.
     """
 
-    def __init__(self, form="NFKC", expression=default_pattern, gaps=False):
+    def __init__(self, form: str = "NFKC", expression: str | re.Pattern[str] = default_pattern, gaps: bool = False,):
         """
         :param form: the normalization form to apply, any value accepted by
             :func:`unicodedata.normalize` -- ``"NFC"``, ``"NFD"``, ``"NFKC"``
@@ -266,7 +270,7 @@ class NormalizingRegexTokenizer(RegexTokenizer):
             and self.expression.pattern == other.expression.pattern
         )
 
-    def __call__(self, value, *args, **kwargs):
+    def __call__(self, value: str, *args: Any, **kwargs: Any) -> Iterator[Token]:
         assert isinstance(value, str), f"{value!r} is not unicode"
         value = unicodedata.normalize(self.form, value)
         return super().__call__(value, *args, **kwargs)
@@ -297,7 +301,7 @@ class CharsetTokenizer(Tokenizer):
 
     __inittype__ = {"charmap": str}
 
-    def __init__(self, charmap):
+    def __init__(self, charmap: Any):
         """
         :param charmap: a mapping from integer character numbers to unicode
             characters, as used by the unicode.translate() method.
@@ -313,17 +317,17 @@ class CharsetTokenizer(Tokenizer):
 
     def __call__(
         self,
-        value,
-        positions=False,
-        chars=False,
-        keeporiginal=False,
-        removestops=True,
-        start_pos=0,
-        start_char=0,
-        tokenize=True,
-        mode="",
-        **kwargs,
-    ):
+        value: str,
+        positions: bool = False,
+        chars: bool = False,
+        keeporiginal: bool = False,
+        removestops: bool = True,
+        start_pos: int = 0,
+        start_char: int = 0,
+        tokenize: bool = True,
+        mode: str = "",
+        **kwargs: Any,
+    ) -> Iterator[Token]:
         """
         :param value: The unicode string to tokenize.
         :param positions: Whether to record token positions in the token.
@@ -389,7 +393,7 @@ class CharsetTokenizer(Tokenizer):
                 yield t
 
 
-def SpaceSeparatedTokenizer():
+def SpaceSeparatedTokenizer() -> RegexTokenizer:
     """Returns a RegexTokenizer that splits tokens by whitespace.
 
     >>> sst = SpaceSeparatedTokenizer()
@@ -400,7 +404,7 @@ def SpaceSeparatedTokenizer():
     return RegexTokenizer(r"[^ \t\r\n]+")
 
 
-def CommaSeparatedTokenizer():
+def CommaSeparatedTokenizer() -> Composable:
     """Splits tokens by commas.
 
     Note that the tokenizer calls unicode.strip() on each match of the regular
@@ -421,10 +425,16 @@ class PathTokenizer(Tokenizer):
     ``["/a", "/a/b", "/a/b/c"]``.
     """
 
-    def __init__(self, expression="[^/]+"):
+    def __init__(self, expression: str | re.Pattern[str] = "[^/]+"):
         self.expr = rcompile(expression)
 
-    def __call__(self, value, positions=False, start_pos=0, **kwargs):
+    def __call__(
+        self,
+        value: str,
+        positions: bool = False,
+        start_pos: int = 0,
+        **kwargs: Any,
+    ) -> Iterator[Token]:
         assert isinstance(value, str), f"{value!r} is not unicode"
         token = Token(positions, **kwargs)
         pos = start_pos

--- a/tests/typing_smoke.py
+++ b/tests/typing_smoke.py
@@ -26,7 +26,15 @@ from whoosh.analysis.ngrams import (
     NgramTokenizer,
     NgramWordAnalyzer,
 )
-from whoosh.analysis.tokenizers import RegexTokenizer
+from whoosh.analysis.tokenizers import (
+    CharsetTokenizer,
+    CommaSeparatedTokenizer,
+    IDTokenizer,
+    NormalizingRegexTokenizer,
+    PathTokenizer,
+    RegexTokenizer,
+    SpaceSeparatedTokenizer,
+)
 from whoosh.fields import DATETIME, ID, NUMERIC, TEXT, Schema
 from whoosh.qparser import QueryParser
 from whoosh.query import (
@@ -474,6 +482,13 @@ def run() -> list[str]:
     gram_texts: list[str] = [str(tok.text) for tok in ngram_analyzer("hi there")]
     word_texts: list[str] = [str(tok.text) for tok in word_analyzer("hello there")]
     assert gram_texts and word_texts
+
+    # whoosh.analysis.tokenizers public API (gh#72)
+    tok_id = IDTokenizer()
+    tok_norm = NormalizingRegexTokenizer()
+    tok_path = PathTokenizer()
+    assert list(tok_id("test")) and list(tok_norm("test")) and list(tok_path("a/b"))
+    assert list(SpaceSeparatedTokenizer()("a b")) and list(CommaSeparatedTokenizer()("a,b"))
 
     return titles
 


### PR DESCRIPTION
## Summary

Adds PEP 484 type annotations to `src/whoosh/analysis/tokenizers.py` and expands the smoke test in `tests/typing_smoke.py`.

* Added `from __future__ import annotations` and imports under `TYPE_CHECKING`.
* Annotated public classes: `IDTokenizer`, `RegexTokenizer`, `NormalizingRegexTokenizer`, `CharsetTokenizer`, `PathTokenizer`, and helper functions.
* Typed generator return signatures as `Iterator[Token]`.
* Added public API checks to `tests/typing_smoke.py`.

## Related issues

Closes #72

## Checklist

- [x] Annotation-only changes (no runtime behavior changes)
- [x] Added checks to `tests/typing_smoke.py`