### PR TITLE
fix: define default_pattern before RegexTokenizer usage (#72)

### DIFF
--- a/src/whoosh/analysis/tokenizers.py
+++ b/src/whoosh/analysis/tokenizers.py
@@ -78,6 +78,13 @@ class IDTokenizer(Tokenizer):
         yield t
 
 
+import re
+from typing import TYPE_CHECKING, Iterator
+
+# Define default_pattern at module level OUTSIDE of TYPE_CHECKING
+default_pattern = re.compile(r"\w+")
+
+
 class RegexTokenizer(Tokenizer):
     """
     Uses a regular expression to extract tokens from text.


### PR DESCRIPTION
## Summary

* Moved `default_pattern` definition to module scope before `RegexTokenizer` definition in `src/whoosh/analysis/tokenizers.py`.
* Resolves `NameError: name 'default_pattern' is not defined` during pytest collection in CI checks.

## Related issues

Fixes #72