### PR TITLE
Add type hints to analysis core

### DIFF
--- a/src/whoosh/analysis/acore.py
+++ b/src/whoosh/analysis/acore.py
@@ -1,3 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from whoosh.analysis.analyzers import CompositeAnalyzer
+
+
 # Copyright 2007 Matt Chaput. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -101,9 +109,22 @@ class Token:
     ...or, call token.copy() to get a copy of the token object.
     """
 
+    text: str
+    positions: bool
+    chars: bool
+    stopped: bool
+    boost: float
+    removestops: bool
+    mode: str
+
     def __init__(
-        self, positions=False, chars=False, removestops=True, mode="", **kwargs
-    ):
+        self,
+        positions: bool = False,
+        chars: bool = False,
+        removestops: bool = True,
+        mode: str = "",
+        **kwargs: Any,
+    ) -> None:
         """
         :param positions: Whether tokens should have the token position in the
             'pos' attribute.
@@ -123,11 +144,11 @@ class Token:
         self.mode = mode
         self.__dict__.update(kwargs)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         parms = ", ".join(f"{name}={value!r}" for name, value in self.__dict__.items())
         return f"{self.__class__.__name__}({parms})"
 
-    def copy(self):
+    def copy(self) -> Token:
         # This is faster than using the copy module
         return Token(**self.__dict__)
 
@@ -136,16 +157,16 @@ class Token:
 
 
 class Composable:
-    is_morph = False
+    is_morph: bool = False
 
-    def __or__(self, other):
+    def __or__(self, other: Composable) -> CompositeAnalyzer:
         from whoosh.analysis.analyzers import CompositeAnalyzer
 
         if not isinstance(other, Composable):
             raise TypeError(f"{self!r} is not composable with {other!r}")
         return CompositeAnalyzer(self, other)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         attrs = ""
         if self.__dict__:
             attrs = ", ".join(
@@ -153,5 +174,5 @@ class Composable:
             )
         return self.__class__.__name__ + f"({attrs})"
 
-    def has_morph(self):
+    def has_morph(self) -> bool:
         return self.is_morph

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -5,6 +5,19 @@ from whoosh import analysis, fields, qparser
 from whoosh.filedb.filestore import RamStorage
 
 
+def test_acore_public_type_annotations():
+    token_annotations = analysis.Token.__init__.__annotations__
+    assert token_annotations["positions"] in (bool, "bool")
+    assert token_annotations["chars"] in (bool, "bool")
+    assert token_annotations["removestops"] in (bool, "bool")
+    assert token_annotations["mode"] in (str, "str")
+    assert token_annotations["return"] in (None, type(None), "None")
+
+    composable_annotations = analysis.Composable.__or__.__annotations__
+    assert composable_annotations["other"] in (analysis.Composable, "Composable")
+    assert composable_annotations["return"] in ("CompositeAnalyzer",)
+
+
 def test_regextokenizer():
     value = "AAAaaaBBBbbbCCCcccDDDddd"
 

--- a/tests/typing_smoke.py
+++ b/tests/typing_smoke.py
@@ -505,7 +505,7 @@ def run() -> list[str]:
     tokenizer = RegexTokenizer()
     lc_filter = LowercaseFilter()
     lc_tokens: Iterator[Token] = lc_filter(tokenizer("Hello World"))
-    assert all(tok.text == tok.text.lower() for tok in lc_tokens)  # type: ignore[attr-defined]
+    assert all(tok.text == tok.text.lower() for tok in lc_tokens)
     strip_filter = StripFilter()
     strip_tokens: Iterator[Token] = strip_filter(tokenizer("  hello  "))
     assert all(isinstance(tok, Token) for tok in strip_tokens)


### PR DESCRIPTION
Closes #80\n\nThis adds PEP 484 annotations to Token and Composable while preserving Token's dynamic attributes and the runtime CompositeAnalyzer import. It includes a small annotation regression test.\n\nVerification:\n- PYTHONPATH=src python -m pytest -p no:recording tests/test_analysis.py -q (43 passed)\n- python -m compileall -q src/whoosh/analysis/acore.py\n- git diff --check\n\nRuff was not available in this Windows environment.