### PR TITLE
fix(typing): add type annotations for whoosh.analysis.morph (#77)

### DIFF
--- a/src/whoosh/analysis/morph.py
+++ b/src/whoosh/analysis/morph.py
@@ -25,6 +25,13 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterator
+
+if TYPE_CHECKING:
+    from whoosh.analysis.tokenizers import Token
+    
 from whoosh.analysis.filters import Filter
 from whoosh.lang.dmetaphone import double_metaphone
 from whoosh.lang.porter import stem

--- a/src/whoosh/analysis/morph.py
+++ b/src/whoosh/analysis/morph.py
@@ -137,7 +137,7 @@ class StemFilter(Filter):
             other and self.__class__ is other.__class__ and self.stemfn == other.stemfn
         )
 
-    def __call__(self, tokens):
+    def __call__(self, tokens: Iterator[Token]) -> Iterator[Token]:
         stemfn = self._stem
         ignore = self.ignore
 
@@ -246,7 +246,7 @@ class DoubleMetaphoneFilter(Filter):
             and self.primary_boost == other.primary_boost
         )
 
-    def __call__(self, tokens):
+    def __call__(self, tokens: Iterator[Token]) -> Iterator[Token]:
         primary_boost = self.primary_boost
         secondary_boost = self.secondary_boost
         combine = self.combine


### PR DESCRIPTION
Adds static type annotations (`Iterator[Token]`) to `whoosh.analysis.morph` (`StemFilter` and `DoubleMetaphoneFilter`).

Closes #77