### PR TITLE
perf: skip zlib for postings blocks below the measured crossover

### DIFF
--- a/src/whoosh/codec/whoosh3.py
+++ b/src/whoosh/codec/whoosh3.py
@@ -65,6 +65,10 @@ except ImportError:
 # codec/version
 WHOOSH3_HEADER_MAGIC = b"W3Bl"
 
+# Below this pickled-block size, zlib reliably expands the payload
+# (measured crossover on the reuters benchmark corpus; see issue #99).
+COMPRESSION_MIN_SIZE = 80
+
 # Column type to store field length info
 LENGTHS_COLUMN = columns.NumericColumn("B", default=0)
 # Column type to store pointers to vector posting lists
@@ -816,16 +820,16 @@ class W3PostingsWriter(base.PostingsWriter):
         # Pickle the tuple
         databytes = dumps(data, 2)
         # Compress the pickle (if self._compression > 0), but skip compression
-        # for a payload so small that zlib's header would only add overhead
-        # instead of shrinking it. NOTE: the previous code set ``comp = 0`` here
-        # and then immediately overwrote it with ``comp = self._compression``,
-        # so this tiny-block skip never actually took effect. Ordered correctly
-        # now. (The threshold is conservative — the smallest real block pickle
-        # is ~56 bytes — so this is behaviourally a no-op today; raising it to
-        # skip compression on single-posting blocks of rare terms is tracked as
-        # a follow-up optimization.)
+        # for payloads below COMPRESSION_MIN_SIZE, where zlib's header and
+        # checksum expand the data instead of shrinking it while still
+        # costing CPU. Measured on the reuters benchmark corpus: no block
+        # under 80 bytes ever compressed smaller, and the sub-80 range is
+        # dominated by single-posting blocks of rare terms (roughly half of
+        # all blocks in a Zipfian vocabulary); from 80 bytes up, compression
+        # always helped. The read path honours the stored compression flag,
+        # so uncompressed blocks are format-legal.
         comp = self._compression
-        if len(databytes) < 20:
+        if len(databytes) < COMPRESSION_MIN_SIZE:
             comp = 0
         if comp:
             databytes = zlib.compress(databytes, comp)

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -827,3 +827,67 @@ def test_whoosh2_legacy_codec_importable():
     ):
         assert hasattr(w2, name), name
     assert issubclass(w2.NoGraphError, Exception)
+
+
+def test_tiny_blocks_stored_uncompressed_round_trip(tmp_path):
+    # Single-posting terms produce postings blocks below
+    # COMPRESSION_MIN_SIZE, which are stored uncompressed because zlib
+    # expands payloads that small. The stored compression flag must say
+    # so, and the terms must read back exactly (issue #99).
+    from whoosh import index
+    from whoosh.codec import whoosh3
+    from whoosh.qparser import QueryParser
+
+    d = str(tmp_path)
+    schema = fields.Schema(id=fields.ID(stored=True), body=fields.TEXT)
+    ix = index.create_in(d, schema)
+    w = ix.writer()
+    # Every rare_N term occurs exactly once, in one document: the
+    # single-posting shape that dominates Zipfian vocabularies.
+    for i in range(50):
+        w.add_document(id=str(i), body=u(f"common rare_{i}"))
+    w.commit()
+
+    ix2 = index.open_dir(d)
+    with ix2.searcher() as s:
+        qp = QueryParser("body", ix2.schema)
+        # Every single-posting term is findable in its one document.
+        for i in range(50):
+            hits = s.search(qp.parse(u(f"rare_{i}")), limit=None)
+            assert [hit["id"] for hit in hits] == [str(i)], f"rare_{i}"
+        # The common term appears everywhere.
+        assert len(s.search(qp.parse(u("common")), limit=None)) == 50
+
+    # The guard itself, pinned for real: rebuild the same index with
+    # zlib.compress replaced by a tripwire, and prove no payload below
+    # the threshold is ever handed to zlib.
+    import zlib as real_zlib
+
+    calls = []
+
+    class TripwireZlib:
+        @staticmethod
+        def compress(data, level=6):
+            calls.append(len(data))
+            assert len(data) >= whoosh3.COMPRESSION_MIN_SIZE, (
+                f"zlib called for a {len(data)} byte block below the "
+                f"{whoosh3.COMPRESSION_MIN_SIZE} byte threshold"
+            )
+            return real_zlib.compress(data, level)
+
+        decompress = staticmethod(real_zlib.decompress)
+
+    (tmp_path / "tripwire").mkdir()
+    d2 = str(tmp_path / "tripwire")
+    old_zlib = whoosh3.zlib
+    whoosh3.zlib = TripwireZlib
+    try:
+        ix3 = index.create_in(d2, schema)
+        w3 = ix3.writer()
+        for i in range(50):
+            w3.add_document(id=str(i), body=u(f"common rare_{i}"))
+        w3.commit()
+    finally:
+        whoosh3.zlib = old_zlib
+    # Compression still ran for payloads at or above the threshold.
+    assert calls, "expected at least one compressed block"


### PR DESCRIPTION
## Summary

Raises the small-block compression-skip threshold in the whoosh3 codec from 20 to a measured crossover of 80 bytes, as a named constant (COMPRESSION_MIN_SIZE). Instrumenting _write_block on the reuters benchmark corpus showed no pickled block under 80 bytes ever compressed smaller, and that range is dominated by single-posting blocks of rare terms (4194 of 8989 blocks in the sample), each stored expanded by zlib's header while costing CPU. From 80 bytes up, compression always helped.

Measured effect, best of three builds on the reuters corpus: build time 0.462s against 0.499s, and the on-disk index shrinks by 4185 bytes, so size does not regress. Happy to rerun numbers with the maintainer's preferred harness settings.

## Related issues

Fixes #99

## Checklist

- [x] Tests pass locally (`pytest tests/`): 854 passed, 3 skipped
- [x] Added/updated tests: a round-trip test over single-posting terms, plus a zlib tripwire that pins the guard and fails against the old threshold
- [ ] Updated docs / CHANGELOG if user-facing: internal codec behavior, no user-facing surface changed
- [x] I have read the CONTRIBUTING guide

Note on ruff: the new test uses function-level imports to match the established style of tests/test_codecs.py; ruff flags these the same way it flags the file's pre-existing tests.