### PR TITLE
pre-commit: Add the extremely fast Python type checker ty

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,11 @@ repos:
         args: [ --fix ]
       - id: ruff-format
 
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.74
+    hooks:
+      - id: ty
+
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: '0.26'
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,3 +177,6 @@ follow_imports = "silent"
 python_version = "3.10"
 warn_redundant_casts = true
 warn_unused_ignores = true
+
+[tool.ty]
+src.include = [ "tests/typing_smoke.py" ]


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

Add an extremely fast Python type checker and language server, written in Rust.
* https://docs.astral.sh/ty

Pre-commit hooks should have subsecond run times, or when run locally, developers may lose context and focus.

`ty` is much faster and more capable than `mypy` and is backed by [Astral](https://astral.sh/), the creators of [uv](https://github.com/astral-sh/uv) and [Ruff](https://github.com/astral-sh/ruff).

Across many projects, I have found that `ty` is easier to deal with and provides more useful typing results than `mypy`.

## Related issues

<!-- e.g. Fixes #123 -->

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [x] Added/updated tests for the change where it makes sense
- [ ] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](https://github.com/priya-sundaram-dev/whoosh/blob/main/CONTRIBUTING.md) guide
