### PR TITLE
Type-check the entire codebase with ty, with lots of rules ignored

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,4 +179,27 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 
 [tool.ty]
-src.include = [ "tests/typing_smoke.py" ]
+# TODO: Gradual typing: Revisit these ignores and remove them as the codebase is
+# incrementally typed (gh#3).  The instance comments below were calculated in the
+# past so they should be treated as a historical reference, not a current count.
+rules.call-non-callable = "ignore"  # 20 instances
+rules.empty-body = "ignore"  # 1 instance
+rules.invalid-argument-type = "ignore"  # 91 instances
+rules.invalid-assignment = "ignore"  # 23 instances
+rules.invalid-ignore-comment = "ignore"  # 1 instance
+rules.invalid-method-override = "ignore"  # 132 instances
+rules.invalid-raise = "ignore"  # 3 instances
+rules.invalid-return-type = "ignore"  # 28 instances
+rules.invalid-type-form = "ignore"  # 2 instances
+rules.invalid-yield = "ignore"  # 3 instances
+rules.missing-argument = "ignore"  # 12 instances
+rules.no-matching-overload = "ignore"  # 2 instances
+rules.not-iterable = "ignore"  # 7 instances
+rules.not-subscriptable = "ignore"  # 15 instances
+rules.parameter-already-assigned = "ignore"  # 1 instance
+rules.too-many-positional-arguments = "ignore"  # 29 instances
+rules.unknown-argument = "ignore"  # 10 instances
+rules.unresolved-attribute = "ignore"  # 499 instances
+rules.unresolved-import = "ignore"  # 63 instances
+rules.unsupported-operator = "ignore"  # 32 instances
+rules.unused-type-ignore-comment = "ignore"  # 41 instances


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

Type-check the entire codebase with ty, with lots of rules ignored.  This puts guardrails in place so that `ty` can catch all typing rules that are not ignored.  Provide opportunities to unignore ty rules as we gradually implement Python typing.

Fixing typing rules can be complicated, so future typing pull requests should unignore one or two rules to simplify the code review process.

## Related issues
* #117

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [x] Added/updated tests for the change where it makes sense
- [ ] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](https://github.com/priya-sundaram-dev/whoosh/blob/main/CONTRIBUTING.md) guide
