### PR TITLE
Ty: Unignore rule invalid-type-form

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ warn_unused_ignores = true
 
 [tool.ty]
 # TODO: Gradual typing: Revisit these ignores and remove them as the codebase is
-# incrementally typed (gh#3).  The instance comments below were calculated in the
+# incrementally typed (gh#121).  The instance comments below were calculated in the
 # past so they should be treated as a historical reference, not a current count.
 rules.call-non-callable = "ignore"  # 20 instances
 rules.empty-body = "ignore"  # 1 instance
@@ -190,7 +190,6 @@ rules.invalid-ignore-comment = "ignore"  # 1 instance
 rules.invalid-method-override = "ignore"  # 132 instances
 rules.invalid-raise = "ignore"  # 3 instances
 rules.invalid-return-type = "ignore"  # 28 instances
-rules.invalid-type-form = "ignore"  # 2 instances
 rules.missing-argument = "ignore"  # 12 instances
 rules.no-matching-overload = "ignore"  # 2 instances
 rules.not-iterable = "ignore"  # 7 instances

--- a/src/whoosh/fields.py
+++ b/src/whoosh/fields.py
@@ -38,12 +38,12 @@ import struct
 import sys
 from array import array
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
-    FieldSpec = "FieldType | type[FieldType]"
+    FieldSpec: TypeAlias = "FieldType | type[FieldType]"
 
     from collections.abc import Generator
 


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

Stop ignoring `ty` rule https://docs.astral.sh/ty/reference/rules/#invalid-type-form

## Related issues

* #121

Blocked by: #124
* #124

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [x] Added/updated tests for the change where it makes sense
- [ ] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](https://github.com/priya-sundaram-dev/whoosh/blob/main/CONTRIBUTING.md) guide
