### PR TITLE
docs: purge residual Python 3.9 references after the 3.9 drop (#124)

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,1 @@
-sonar.python.version=3.8, 3.9, 3.10, 3.11, 3.12
+sonar.python.version=3.10, 3.11, 3.12, 3.13, 3.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. This project follows
 ## [Unreleased]
 
 ### Internal / tooling
+- Swept residual `3.9` references left over from the Python 3.9 drop (#124):
+  the docs (`index.rst`, `integrations.rst`, `migrating.rst`, `MIGRATING.md`),
+  the roadmap, the demo/marketing pages (which advertised "Python 3.9–3.14"),
+  and `.sonarcloud.properties` (which still listed 3.8/3.9) now all state the
+  3.10–3.14 support range. Docs-only; thanks @cclauss for the catch.
 - **Consolidated packaging/tooling config into `pyproject.toml`** (#125). The
   active pytest config (`addopts`, `filterwarnings`, `norecursedirs`, …) moved
   from `setup.cfg`'s `[tool:pytest]` into `[tool.pytest.ini_options]`, and

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -80,7 +80,7 @@ drop them.
 - Metadata moved to a PEP 621 `pyproject.toml`.
 - Wheels are published for install; `python -m build` produces a clean sdist
   and wheel.
-- `requires-python = ">=3.9"`, with classifiers and CI coverage through
+- `requires-python = ">=3.10"`, with classifiers and CI coverage through
   Python 3.14.
 
 ### 3. Bug fixes you may care about

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -215,16 +215,16 @@ About section of the README.)*
 - [x] **Python 3.14 support (3.11.0).** Verified the full suite passes on the
       latest stable CPython (3.14.0, released 2025-10-07), added it to the CI
       matrix, and shipped the `Programming Language :: Python :: 3.14`
-      classifier. Whoosh now supports 3.9–3.14.
+      classifier. Whoosh now supports 3.10–3.14.
 - [ ] Triage the inherited issue backlog; label, reproduce, close stale. Two
       long-standing bugs already fixed (gh#99, gh#116); more to review.
-- [ ] **Python support policy.** CI now also exercises the 3.15 / 3.15t
+- [x] **Python support policy.** CI now also exercises the 3.15 / 3.15t
       release candidates (non-blocking until 3.15.0 final; gh#104 follow-up).
-      Python 3.9 is past upstream end-of-life, but the 3.9 floor stays through
-      the current 3.x line — the maintenance cost is ~zero while the suite is
-      green, and there is still a long tail of pinned-3.9 deployments installing
-      `whoosh3`. The floor will be raised to 3.10 in the next minor, announced
-      in the changelog and here before it lands, so no one is surprised.
+      Python 3.9 reached upstream end-of-life in October 2025, so the floor was
+      raised to **3.10** (gh#124), unblocking modern typing constructs without
+      version guards. `pip` respects `requires-python`, so deployments still on
+      3.9 keep resolving the last 3.9-compatible release (3.44.0) — nothing
+      breaks for existing users. Announced in the changelog before it landed.
 - [x] **`whoosh.analysis` typing sweep complete (gh#82, in `[Unreleased]`).**
       The last self-contained analysis module, `whoosh.analysis.intraword`
       (`CompoundWordFilter`, `BiWordFilter`, `ShingleFilter`,

--- a/demo/blog.html
+++ b/demo/blog.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Whoosh is back: reviving pure-Python full-text search" />
@@ -155,7 +155,7 @@
   Every one of these landed with a regression test. <code>pip install -U whoosh3</code>.</p>
 
   <p><strong>Update (3.11.x) — Python 3.14 and two scoring/reader fixes.</strong>
-  Whoosh now runs on <em>Python 3.9 through 3.14</em>, with the latest stable
+  Whoosh now runs on <em>Python 3.10 through 3.14</em>, with the latest stable
   CPython in CI (3.11.0). Two correctness fixes followed, each with a regression
   test: boosts on multi-term queries (<code>Prefix</code>, <code>Wildcard</code>,
   <code>FuzzyTerm</code>, <code>TermRange</code>) are now actually applied to the
@@ -264,7 +264,7 @@
     A truly pure-Python, no-compile install that works anywhere CPython runs —
     including PyPy and the browser via Pyodide.</li>
     <li><strong>Modern packaging</strong> (PEP 621) and a CI matrix across
-    Python 3.9–3.14.</li>
+    Python 3.10–3.14.</li>
     <li><strong>Two long-standing bugs fixed</strong>, each with a regression test:
       <ul>
         <li><code>MultiFilter</code> no longer throws <code>StopIteration</code>

--- a/demo/django-full-text-search.html
+++ b/demo/django-full-text-search.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Add full-text search to a Django app in pure Python (Whoosh)" />

--- a/demo/fastapi-full-text-search.html
+++ b/demo/fastapi-full-text-search.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Add full-text search to a FastAPI app in pure Python (Whoosh)" />

--- a/demo/flask-full-text-search.html
+++ b/demo/flask-full-text-search.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Add full-text search to a Flask app in pure Python (Whoosh)" />

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,7 +14,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Whoosh — pure-Python full-text search in the browser" />

--- a/demo/is-whoosh-still-maintained.html
+++ b/demo/is-whoosh-still-maintained.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Is Whoosh still maintained? (2026 status)" />
@@ -30,7 +30,7 @@
       "name": "Is Whoosh still maintained in 2026?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "The original Whoosh (by Matt Chaput) and the whoosh-reloaded fork are both effectively unmaintained. An actively-maintained continuation is published on PyPI as whoosh3, which keeps the import name whoosh, supports Python 3.9 through 3.14, and ships regular releases."
+        "text": "The original Whoosh (by Matt Chaput) and the whoosh-reloaded fork are both effectively unmaintained. An actively-maintained continuation is published on PyPI as whoosh3, which keeps the import name whoosh, supports Python 3.10 through 3.14, and ships regular releases."
       }
     },
     {
@@ -46,7 +46,7 @@
       "name": "Does Whoosh work on Python 3.14?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "The original Whoosh 2.7.4 does not install cleanly on modern Python. The whoosh3 continuation is tested on CPython 3.9 through 3.14 and on PyPy, and is pure Python with no C build step."
+        "text": "The original Whoosh 2.7.4 does not install cleanly on modern Python. The whoosh3 continuation is tested on CPython 3.10 through 3.14 and on PyPy, and is pure Python with no C build step."
       }
     }
   ]
@@ -103,7 +103,7 @@
     actively-maintained continuation on PyPI called
     <a href="https://pypi.org/project/whoosh3/"><code>whoosh3</code></a>. It keeps
     the import name <code>whoosh</code>, so it is a drop-in replacement, and it is
-    tested on Python 3.9&ndash;3.14. Install it with
+    tested on Python 3.10&ndash;3.14. Install it with
     <code>pip install whoosh3</code>.
   </div>
 
@@ -140,7 +140,7 @@
   <p>I picked Whoosh back up and have been maintaining it in the open. Concretely,
   the <code>whoosh3</code> package today:</p>
   <ul>
-    <li>installs and runs on <strong>CPython 3.9 through 3.14</strong> and on PyPy,
+    <li>installs and runs on <strong>CPython 3.10 through 3.14</strong> and on PyPy,
       with a green CI matrix;</li>
     <li>is still <strong>pure Python</strong> &mdash; no C toolchain, no native
       wheels, no separate service;</li>

--- a/demo/migrate-sqlite-fts5-to-whoosh.html
+++ b/demo/migrate-sqlite-fts5-to-whoosh.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Migrating from SQLite FTS5 to Whoosh" />

--- a/demo/search-files-command-line.html
+++ b/demo/search-files-command-line.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="grep, but ranked — the Whoosh CLI" />

--- a/demo/whoosh-analyzer-recipes.html
+++ b/demo/whoosh-analyzer-recipes.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Whoosh analyzer recipes" />

--- a/demo/whoosh-autocomplete-prefix-search.html
+++ b/demo/whoosh-autocomplete-prefix-search.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Autocomplete & prefix search in Whoosh" />

--- a/demo/whoosh-faceted-search-counts.html
+++ b/demo/whoosh-faceted-search-counts.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Faceted search & result counts with Whoosh" />

--- a/demo/whoosh-highlight-search-snippets.html
+++ b/demo/whoosh-highlight-search-snippets.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Highlighted search-result snippets with Whoosh" />

--- a/demo/whoosh-incremental-index-sync.html
+++ b/demo/whoosh-incremental-index-sync.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Keep a Whoosh index in sync incrementally" />

--- a/demo/whoosh-langchain-retriever.html
+++ b/demo/whoosh-langchain-retriever.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Use Whoosh as a LangChain retriever (pure-Python BM25)" />
@@ -249,7 +249,7 @@ results = hybrid.invoke("BM25 vs embeddings for exact matches")</code></pre>
     cluster, no separate BM25 service — the index is just files on disk in the
     same process as your chain.</li>
     <li><strong>Pure Python.</strong> No C extensions to compile; the same wheel
-    runs on Python 3.9–3.14, in Lambda, and in slim containers.</li>
+    runs on Python 3.10–3.14, in Lambda, and in slim containers.</li>
     <li><strong>Real BM25F.</strong> Field-weighted BM25, exact phrase and
     prefix queries, and metadata filtering built in.</li>
     <li><strong>Incremental updates.</strong> <code>update_document</code> lets

--- a/demo/whoosh-llamaindex-retriever.html
+++ b/demo/whoosh-llamaindex-retriever.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Use Whoosh as a LlamaIndex retriever (pure-Python BM25)" />
@@ -187,7 +187,7 @@ nodes = hybrid.retrieve("BM25 vs embeddings for exact matches")</code></pre>
     cluster, no separate BM25 service — the index lives in the same process as
     your LlamaIndex app.</li>
     <li><strong>Pure Python.</strong> No C extensions to compile; the same wheel
-    runs on Python 3.9–3.14, in AWS Lambda, and in slim containers.</li>
+    runs on Python 3.10–3.14, in AWS Lambda, and in slim containers.</li>
     <li><strong>Real BM25F.</strong> Field-weighted BM25, exact phrase and
     prefix queries, and metadata filtering built in.</li>
     <li><strong>Importable anywhere.</strong> The <code>WhooshSearch</code> core

--- a/demo/whoosh-mcp-server-agent-search-tool.html
+++ b/demo/whoosh-mcp-server-agent-search-tool.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Whoosh as an MCP server for AI agents" />
@@ -97,7 +97,7 @@
   <pre><code>pip install "whoosh3[mcp]"</code></pre>
   <p>
     <code>whoosh3</code> is the actively-maintained continuation of Whoosh
-    (Python 3.9–3.14); the <code>[mcp]</code> extra pulls in the official Model
+    (Python 3.10–3.14); the <code>[mcp]</code> extra pulls in the official Model
     Context Protocol SDK.
   </p>
 
@@ -232,7 +232,7 @@ docker run --rm -i -v "$HOME/notes:/corpus:ro" whoosh-mcp /corpus</code></pre>
     <li><strong>Real BM25F ranking</strong>, plus phrase, boolean, range, prefix
       and fielded queries when a bag of terms isn't enough.</li>
     <li><strong>Actively maintained again.</strong> <code>pip install whoosh3</code>
-      installs the current release with Python 3.9–3.14 support.</li>
+      installs the current release with Python 3.10–3.14 support.</li>
   </ul>
 
   <div class="cta">

--- a/demo/whoosh-performance-tuning-fast-indexing.html
+++ b/demo/whoosh-performance-tuning-fast-indexing.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Whoosh performance tuning: fast indexing & search" />
@@ -246,7 +246,7 @@ finally:
 
   <div class="cta">
     <p style="margin:.2rem 0"><strong>Whoosh is maintained again.</strong> Pure
-    Python, zero runtime dependencies, BSD-2-Clause, tested on Python 3.9–3.14.</p>
+    Python, zero runtime dependencies, BSD-2-Clause, tested on Python 3.10–3.14.</p>
     <p style="margin:.5rem 0">
       <a href="https://github.com/priya-sundaram-dev/whoosh">⭐ Star Whoosh on GitHub</a>
       &nbsp;·&nbsp;

--- a/demo/whoosh-python-3-importerror-fix.html
+++ b/demo/whoosh-python-3-importerror-fix.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Whoosh ImportError on modern Python — the fix" />
@@ -38,7 +38,7 @@
       "name": "Why does Whoosh raise ModuleNotFoundError: No module named 'imp'?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "The imp module was deprecated for years and removed in Python 3.12. Code paths in old Whoosh that touch it break on Python 3.12 and later. The maintained whoosh3 package no longer depends on imp and is tested on Python 3.9 through 3.14."
+        "text": "The imp module was deprecated for years and removed in Python 3.12. Code paths in old Whoosh that touch it break on Python 3.12 and later. The maintained whoosh3 package no longer depends on imp and is tested on Python 3.10 through 3.14."
       }
     },
     {
@@ -107,7 +107,7 @@
 pip install whoosh3</code></pre>
     Your <code>import whoosh</code> statements, your code, and your existing
     on-disk indexes all keep working &mdash; <code>whoosh3</code> keeps the same
-    import name and API and is tested on Python 3.9&ndash;3.14.
+    import name and API and is tested on Python 3.10&ndash;3.14.
   </div>
 
   <h2>The errors you are probably seeing</h2>
@@ -146,7 +146,7 @@ AttributeError: module 'inspect' has no attribute 'getargspec'</code></pre>
   <p>The maintained continuation of Whoosh is published on PyPI as
   <a href="https://pypi.org/project/whoosh3/"><code>whoosh3</code></a>. It fixes
   the imports (they now come from <code>collections.abc</code>), drops
-  <code>imp</code>, and is tested in CI on <strong>CPython 3.9 through 3.14</strong>
+  <code>imp</code>, and is tested in CI on <strong>CPython 3.10 through 3.14</strong>
   and on PyPy. Crucially, it <strong>keeps the import name <code>whoosh</code></strong>,
   so nothing in your source has to change.</p>
 
@@ -188,7 +188,7 @@ with ix.searcher() as s:
     <tbody>
       <tr><td><code>whoosh</code> (2.7.4)</td><td><code>whoosh</code></td><td>Original, last release 2016 — breaks on Python 3.10+</td></tr>
       <tr><td><code>whoosh-reloaded</code></td><td><code>whoosh</code></td><td>Community fork, now inactive</td></tr>
-      <tr><td><code>whoosh3</code></td><td><code>whoosh</code></td><td><strong>Actively maintained</strong>, Python 3.9–3.14</td></tr>
+      <tr><td><code>whoosh3</code></td><td><code>whoosh</code></td><td><strong>Actively maintained</strong>, Python 3.10–3.14</td></tr>
     </tbody>
   </table>
   <p>All three install under the <code>whoosh</code> import name, so only one can

--- a/demo/whoosh-rag-hybrid-search.html
+++ b/demo/whoosh-rag-hybrid-search.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Whoosh for RAG: BM25 keyword retrieval & hybrid search" />
@@ -261,7 +261,7 @@ context = "\n\n".join(id_to_text[cid] for cid in final_ids if cid in id_to_text)
     <li><strong>Real BM25F ranking</strong>, plus phrase, boolean, range, and
       fielded queries when you need more control than a bag of terms.</li>
     <li><strong>Actively maintained again.</strong> <code>pip install whoosh3</code>
-      installs the current release with Python 3.9–3.14 support.</li>
+      installs the current release with Python 3.10–3.14 support.</li>
   </ul>
 
   <div class="cta">

--- a/demo/whoosh-search-pandas-dataframe.html
+++ b/demo/whoosh-search-pandas-dataframe.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Search a pandas DataFrame with Whoosh" />

--- a/demo/whoosh-search-pdf-markdown-knowledge-base.html
+++ b/demo/whoosh-search-pdf-markdown-knowledge-base.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Search a folder of PDFs & Markdown with Whoosh" />
@@ -255,7 +255,7 @@ notes.txt  (score 1.44)
     <p style="margin:.2rem 0 .6rem"><strong>Get started</strong></p>
     <pre style="margin:.3rem 0"><code>pip install whoosh3</code></pre>
     <p style="margin:.5rem 0 0">
-      Same import path (<code>import whoosh</code>), Python 3.9–3.14. Whoosh3 is the
+      Same import path (<code>import whoosh</code>), Python 3.10–3.14. Whoosh3 is the
       actively-maintained continuation of Whoosh. If you build something with it, or
       hit a rough edge, <a href="https://github.com/priya-sundaram-dev/whoosh/issues">open an issue</a> —
       I read every one. Star the <a href="https://github.com/priya-sundaram-dev/whoosh">repo</a> if it helps.

--- a/demo/whoosh-spelling-fuzzy-did-you-mean.html
+++ b/demo/whoosh-spelling-fuzzy-did-you-mean.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Spelling, 'did you mean?', and fuzzy search with Whoosh" />
@@ -254,7 +254,7 @@ with ix.searcher() as s:
     <p style="margin:.2rem 0 .6rem"><strong>Get started</strong></p>
     <pre style="margin:.3rem 0"><code>pip install whoosh3</code></pre>
     <p style="margin:.5rem 0 0">
-      Same import path (<code>import whoosh</code>), Python 3.9–3.14. Whoosh3 is the
+      Same import path (<code>import whoosh</code>), Python 3.10–3.14. Whoosh3 is the
       actively-maintained continuation of Whoosh. If you build something with it, or
       hit a rough edge, <a href="https://github.com/priya-sundaram-dev/whoosh/issues">open an issue</a> —
       I read every one. Star the <a href="https://github.com/priya-sundaram-dev/whoosh">repo</a> if it helps.

--- a/demo/whoosh-vs-elasticsearch.html
+++ b/demo/whoosh-vs-elasticsearch.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Whoosh vs Elasticsearch for Python full-text search" />

--- a/demo/whoosh-vs-sqlite-fts5.html
+++ b/demo/whoosh-vs-sqlite-fts5.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Whoosh vs SQLite FTS5 for Python full-text search" />

--- a/demo/whoosh-vs-tantivy.html
+++ b/demo/whoosh-vs-tantivy.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.9–3.14." />
+<meta property="og:image:alt" content="Whoosh — fast, pure-Python full-text search. pip install whoosh3. Python 3.10–3.14." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="https://priya-sundaram-dev.github.io/whoosh/og-image.png" />
 <meta name="twitter:title" content="Whoosh vs Tantivy for Python full-text search" />

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ New here? Start with the :doc:`quickstart`.
 
     This fork continues Whoosh — originally created by
     `Matt Chaput <mailto:matt@whoosh.ca>`_ — after two rounds of abandonment,
-    now running on Python 3.9–3.14. Install it as ``pip install whoosh3``.
+    now running on Python 3.10–3.14. Install it as ``pip install whoosh3``.
     You can report bugs and request features on the
     `issue tracker <https://github.com/priya-sundaram-dev/whoosh/issues>`_ and
     ask questions in

--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -321,7 +321,7 @@ Why bother? whoosh3 satisfies Haystack's runtime check
 (``whoosh.__version__ >= (2, 5, 0)``) and keeps every public API the backend
 uses (``whoosh.index``, ``whoosh.fields``, ``whoosh.analysis``,
 ``whoosh.filedb.filestore``, ``whoosh.highlight``, ``whoosh.qparser``), while
-adding tested support for **Python 3.9–3.14**. The legacy ``Whoosh==2.7.4`` has
+adding tested support for **Python 3.10–3.14**. The legacy ``Whoosh==2.7.4`` has
 latent breakage on newer interpreters — for example it calls ``cgi.escape`` in
 ``whoosh/compat.py``, and the ``cgi`` module was removed in Python 3.13 — so a
 Haystack project on a current Python is exactly the case whoosh3 is meant to

--- a/docs/source/migrating.rst
+++ b/docs/source/migrating.rst
@@ -95,7 +95,7 @@ Modern packaging
 * Metadata moved to a PEP 621 ``pyproject.toml``.
 * Wheels are published for install; ``python -m build`` produces a clean sdist
   and wheel.
-* ``requires-python = ">=3.9"``, with classifiers and CI coverage through
+* ``requires-python = ">=3.10"``, with classifiers and CI coverage through
   Python 3.14.
 
 Bug fixes you may care about


### PR DESCRIPTION
Follow-up to #124 (dropping Python 3.9). @cclauss rightly nudged with `git grep "3.9"` — the drop left a trail of stale `3.9` references that now misstate the support range.

This sweep updates them all to **3.10–3.14**:
- Docs: `docs/source/index.rst`, `integrations.rst`, `migrating.rst`, `MIGRATING.md` (`requires-python` example)
- `ROADMAP.md`: current-support line + marked the Python-support-policy item done (floor raised to 3.10)
- Demo/marketing pages (`demo/*.html`): `og:image:alt`, JSON-LD, and body copy that advertised "Python 3.9–3.14"
- `.sonarcloud.properties`: was still `3.8, 3.9, 3.10, 3.11, 3.12` → now `3.10–3.14`

Docs/config only — no code changes. The one intentional `3.9` kept is the Whoosh **version** `3.9.0` in `blog.html` and the historical "Done (3.0.0)" roadmap entries.

Thanks @cclauss for the catch.