### PR TITLE
fix(ci): match the demo wheel by its py3 tag, not py2.py3

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,7 +54,7 @@ jobs:
           # Keep the real wheel filename: micropip validates it against PEP 440,
           # so a "latest" pseudo-version is rejected as an invalid wheel name.
           # The real filename is injected into the demo HTML in the next step.
-          cp dist/whoosh3-*-py2.py3-none-any.whl demo/
+          cp dist/whoosh3-*-none-any.whl demo/
 
       - name: Assemble site (demo at root, docs under /docs)
         run: |
@@ -66,7 +66,7 @@ jobs:
           VERSION="$(python -c 'import whoosh; print(whoosh.__version_str__)')"
           sed -i -E "s#(\"softwareVersion\": \")[^\"]*(\")#\1${VERSION}\2#" _site/index.html
           # Inject the real wheel filename so micropip can install it (PEP 440).
-          WHEEL="$(cd dist && ls whoosh3-*-py2.py3-none-any.whl | head -1)"
+          WHEEL="$(cd dist && ls whoosh3-*-none-any.whl | head -1)"
           echo "Demo wheel: ${WHEEL}"
           sed -i "s#__WHEEL_FILENAME__#${WHEEL}#g" _site/index.html
           # Fail loudly if the placeholder was not replaced (guards the live demo).


### PR DESCRIPTION
The Pages **deploy** job builds a wheel for the browser (micropip) demo and copies it with an exact glob. Consolidating packaging config (#126) removed `setup.cfg`, which carried `[bdist_wheel] universal = 1` — so the wheel is now tagged `whoosh3-*-py3-none-any.whl` instead of `*-py2.py3-none-any.whl`, and the hardcoded `cp`/`ls` globs stopped matching (`cp: cannot stat ... py2.py3 ...`, deploy exit 1).

Since `deploy` only runs on push to `main` (not on PRs), the earlier PR CI didnt catch it — the live demo just stopped redeploying.

Fix: drop the `py2.py3` from both globs and match on `*-none-any.whl`, robust to either tag. Verified locally that `python -m build --wheel` produces `whoosh3-3.44.0-py3-none-any.whl` and the new glob matches.