### PR TITLE
Use PEP 639 SPDX license expression in pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to this project are documented here. This project follows
 ## [Unreleased]
 
 ### Internal / tooling
+- Adopted the modern PEP 639 license declaration in `pyproject.toml` (#130):
+  `license` is now the SPDX string `"BSD-2-Clause"` instead of the deprecated
+  `{ text = ... }` table, and the redundant `License :: OSI Approved :: BSD
+  License` classifier was dropped (a SPDX license expression cannot coexist
+  with license classifiers). The build now requires `setuptools>=77`, which
+  understands SPDX expressions and emits `License-Expression` metadata. This
+  silences the `SetuptoolsDeprecationWarning` seen in the Pages build and keeps
+  builds working past setuptools' 2027-02-18 removal deadline. Thanks @cclauss
+  for the report.
 - Swept residual `3.9` references left over from the Python 3.9 drop (#124):
   the docs (`index.rst`, `integrations.rst`, `migrating.rst`, `MIGRATING.md`),
   the roadmap, the demo/marketing pages (which advertised "Python 3.9–3.14"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "setuptools>=64" ]
+requires = [ "setuptools>=77" ]
 
 [project]
 name = "whoosh3"
@@ -10,7 +10,7 @@ description = """\
   """
 readme = "README.md"
 keywords = [ "bm25", "full-text", "index", "search", "spell", "text" ]
-license = { text = "BSD-2-Clause" }
+license = "BSD-2-Clause"
 maintainers = [
   { name = "Priya Sundaram" },
 ]
@@ -21,7 +21,6 @@ requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: BSD License",
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Fixes #130.

The `Deploy` job surfaced a `SetuptoolsDeprecationWarning`: `project.license` as a TOML table is deprecated and will stop building after 2027-02-18.

This switches to the modern [PEP 639](https://peps.python.org/pep-0639/) form:

- `license = { text = "BSD-2-Clause" }` → `license = "BSD-2-Clause"` (SPDX string)
- dropped the `License :: OSI Approved :: BSD License` classifier — setuptools>=77 errors if a SPDX license expression coexists with license classifiers
- bumped the build requirement to `setuptools>=77`, which understands SPDX expressions

Verified locally with `python -m build --wheel`: no deprecation warning, and the wheel `METADATA` now carries `License-Expression: BSD-2-Clause` + `License-File: LICENSE.txt`.

Thanks @cclauss for the report.