### PR TITLE
Release 3.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+## [3.45.0] - 2026-08-24
+
 ### Internal / tooling
 - Adopted the modern PEP 639 license declaration in `pyproject.toml` (#130):
   `license` is now the SPDX string `"BSD-2-Clause"` instead of the deprecated

--- a/demo/index.html
+++ b/demo/index.html
@@ -32,7 +32,7 @@
   "url": "https://priya-sundaram-dev.github.io/whoosh/",
   "downloadUrl": "https://pypi.org/project/whoosh3/",
   "codeRepository": "https://github.com/priya-sundaram-dev/whoosh",
-  "softwareVersion": "3.44.0",
+  "softwareVersion": "3.45.0",
   "license": "https://github.com/priya-sundaram-dev/whoosh/blob/main/LICENSE.txt",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
   "keywords": "full-text search, pure python search, BM25, indexing, information retrieval, whoosh, Flask search, Django search, SQLite FTS alternative",

--- a/demo/is-whoosh-still-maintained.html
+++ b/demo/is-whoosh-still-maintained.html
@@ -148,7 +148,7 @@
       existing on-disk indexes keep working;</li>
     <li>ships tagged releases to PyPI with a
       <a href="https://github.com/priya-sundaram-dev/whoosh/blob/main/CHANGELOG.md">changelog</a>
-      &mdash; the latest is <strong>whoosh3&nbsp;3.44.0</strong> (August&nbsp;2026),
+      &mdash; the latest is <strong>whoosh3&nbsp;3.45.0</strong> (August&nbsp;2026),
       one of a steady run of bug-fix and feature releases shipped this month;</li>
     <li>has a public issue tracker with labeled
       <a href="https://github.com/priya-sundaram-dev/whoosh/issues">good-first-issues</a>

--- a/src/whoosh/__init__.py
+++ b/src/whoosh/__init__.py
@@ -25,7 +25,7 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
-__version__: tuple[int, ...] = (3, 44, 0)
+__version__: tuple[int, ...] = (3, 45, 0)
 #: String form of :data:`__version__`, kept in sync automatically so the two
 #: can never drift. Used as the single source of truth for the packaged version
 #: (see ``pyproject.toml``'s ``version = { attr = "whoosh.__version_str__" }``).


### PR DESCRIPTION
Cuts **3.45.0**, bundling the merged `[Unreleased]` changes.

**Highlights**
- **Dropped Python 3.9** (EOL Oct 2025) — minimum is now Python 3.10 (#124)
- Consolidated packaging/tooling config into `pyproject.toml` (#125)
- Modern PEP 639 SPDX license expression (#130)
- Swept residual `3.9` references across docs and marketing

Version bumped to `(3, 45, 0)`; `python -m build` + `twine check` pass locally on both sdist and wheel. After merge I will publish a GitHub Release `v3.45.0`, which triggers `publish.yml` to upload to PyPI.