### PR TITLE
feat(mcp): support MCP SDK 1.x, 2.x, and standalone FastMCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Added
+- `whoosh.mcp` now works across **every current MCP SDK** — the official MCP
+  Python SDK 2.x (`mcp.server.MCPServer`) *and* 1.x
+  (`mcp.server.fastmcp.FastMCP`), plus the standalone
+  [FastMCP](https://github.com/jlowin/fastmcp) 2.x package (`fastmcp.FastMCP`).
+  `build_mcp_server()` resolves the server class from whichever is installed;
+  all three expose the identical `Server("name")` / `@server.tool()` /
+  `server.run()` surface Whoosh uses, so no configuration is needed. The `mcp`
+  extra is unpinned back to `mcp>=1` (both majors are supported), and a new
+  `fastmcp` extra installs the standalone package: `pip install
+  "whoosh3[fastmcp]"`. The "no SDK installed" error now points at both options.
+  Builds on @mayuriphad's 2.x rename fix (#112) by keeping 1.x installs working.
+
 ## [3.45.0] - 2026-08-24
 
 ### Internal / tooling

--- a/README.md
+++ b/README.md
@@ -150,8 +150,9 @@ reference (all flags, exit codes, and how it maps onto the API):
     — pure-Python retrieval for LLM pipelines, no vector DB required
     (runnable code: [`examples/rag_retriever.py`](examples/rag_retriever.py))
   - [Whoosh as an MCP server: a local search tool for AI agents](https://priya-sundaram-dev.github.io/whoosh/whoosh-mcp-server-agent-search-tool.html)
-    — `pip install "whoosh3[mcp]"` then `whoosh-mcp ~/notes` serves a folder of
-    docs to an agent as `search`/`fetch` tools (module: `whoosh.mcp`)
+    — `pip install "whoosh3[mcp]"` (or `"whoosh3[fastmcp]"` for standalone
+    FastMCP 2.x) then `whoosh-mcp ~/notes` serves a folder of docs to an agent
+    as `search`/`fetch` tools (module: `whoosh.mcp`)
   - [Spelling, "did you mean?", and fuzzy search](https://priya-sundaram-dev.github.io/whoosh/whoosh-spelling-fuzzy-did-you-mean.html)
     — typo tolerance: suggestions, query correction, and fuzzy matching
 - **Docs site:** https://priya-sundaram-dev.github.io/whoosh/ (rebuilt; work in progress)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,12 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 optional-dependencies.dev = [ "mypy", "pre-commit", "pytest>=7", "pytest-cov", "ruff" ]
+optional-dependencies.fastmcp = [ "fastmcp>=2" ]
 optional-dependencies.langchain = [ "langchain-core>=0.3" ]
 optional-dependencies.llamaindex = [ "llama-index-core>=0.10" ]
-optional-dependencies.mcp = [ "mcp>=2" ]
+# whoosh.mcp supports both official SDK majors (1.x FastMCP and 2.x MCPServer),
+# so no upper bound is needed. For the standalone package use the `fastmcp` extra.
+optional-dependencies.mcp = [ "mcp>=1" ]
 urls.Changelog = "https://github.com/priya-sundaram-dev/whoosh/blob/main/CHANGELOG.md"
 urls.Documentation = "https://priya-sundaram-dev.github.io/whoosh/"
 urls.Homepage = "https://github.com/priya-sundaram-dev/whoosh"

--- a/src/whoosh/mcp.py
+++ b/src/whoosh/mcp.py
@@ -194,20 +194,59 @@ class SearchCore:
             return {"id": hit["id"], "title": hit["title"], "text": hit["body"]}
 
 
-def build_mcp_server(core: SearchCore | None = None) -> MCPServer:
-    """Wrap a :class:`SearchCore` in an MCPServer exposing ``search`` + ``fetch``.
+def _load_mcp_server_class() -> type:
+    """Return an MCP server class from whichever MCP SDK is installed.
 
-    Requires the official MCP SDK (``pip install "whoosh3[mcp]"``). If ``core``
-    is ``None``, a corpus directory named in ``WHOOSH_MCP_CORPUS`` is indexed,
-    otherwise the built-in sample documents are used.
+    ``whoosh.mcp`` only uses the small, stable ``Server("name")`` /
+    ``@server.tool()`` / ``server.run()`` surface, which is identical across
+    every current MCP SDK. This loader tries them in order so a single codebase
+    works no matter which one the user has installed:
+
+    * **official MCP Python SDK 2.x** -- ``mcp.server.MCPServer`` (the class
+      formerly known as ``FastMCP``; ``pip install "whoosh3[mcp]"``);
+    * **official MCP Python SDK 1.x** -- ``mcp.server.fastmcp.FastMCP`` (the
+      pre-rename name; same ``@server.tool()`` / ``server.run()`` API); and
+    * **standalone FastMCP 2.x** -- ``fastmcp.FastMCP``
+      (``pip install "whoosh3[fastmcp]"``), the independently maintained package.
+
+    Thanks to @mayuriphad (#112) for identifying the 1.x -> 2.x rename.
     """
     try:
+        # Official MCP SDK 2.x renamed FastMCP -> MCPServer (same tool API).
         from mcp.server import MCPServer  # noqa: PLC0415
+
+        return MCPServer
+    except (ModuleNotFoundError, ImportError):
+        pass
+    try:
+        from mcp.server.fastmcp import FastMCP  # noqa: PLC0415
+
+        return FastMCP
+    except ModuleNotFoundError:
+        pass
+    try:
+        from fastmcp import FastMCP  # noqa: PLC0415
+
+        return FastMCP
     except ModuleNotFoundError as exc:  # pragma: no cover - depends on optional dep
         raise ModuleNotFoundError(
-            "The MCP server requires the 'mcp' package. "
-            'Install it with:  pip install "whoosh3[mcp]"'
+            "The MCP server requires an MCP SDK. Install one of:\n"
+            '  pip install "whoosh3[mcp]"       # official modelcontextprotocol SDK\n'
+            '  pip install "whoosh3[fastmcp]"   # standalone FastMCP 2.x'
         ) from exc
+
+
+def build_mcp_server(core: SearchCore | None = None) -> MCPServer:
+    """Wrap a :class:`SearchCore` in an MCP server exposing ``search`` + ``fetch``.
+
+    Requires an MCP SDK -- either the official ``mcp`` package
+    (``pip install "whoosh3[mcp]"``, SDK 1.x or 2.x) or the standalone
+    ``fastmcp`` 2.x package (``pip install "whoosh3[fastmcp]"``); see
+    :func:`_load_mcp_server_class`. If ``core`` is ``None``, a corpus directory
+    named in ``WHOOSH_MCP_CORPUS`` is indexed, otherwise the built-in sample
+    documents are used.
+    """
+    MCPServer = _load_mcp_server_class()
 
     if core is None:
         corpus = os.environ.get("WHOOSH_MCP_CORPUS")

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -86,17 +86,39 @@ def test_sample_docs_have_required_fields():
         assert {"id", "title", "body"} <= set(d)
 
 
+def _block_mcp_sdks(monkeypatch):
+    """Make every MCP SDK (`mcp` *and* standalone `fastmcp`) unimportable."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mcp" or name.startswith(("mcp.", "fastmcp")):
+            raise ModuleNotFoundError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
 def test_build_mcp_server_without_sdk_raises_helpful_error(monkeypatch):
+    _block_mcp_sdks(monkeypatch)
+    with pytest.raises(ModuleNotFoundError, match=r"whoosh3\[mcp\]"):
+        build_mcp_server(SearchCore.build())
+
+
+def test_build_mcp_server_falls_back_to_standalone_fastmcp(monkeypatch):
+    # With the official `mcp` SDK absent but standalone `fastmcp` present,
+    # build_mcp_server transparently uses fastmcp.FastMCP. Skipped where the
+    # standalone package isn't installed.
+    pytest.importorskip("fastmcp")
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
         if name == "mcp" or name.startswith("mcp."):
-            raise ModuleNotFoundError("No module named 'mcp'")
+            raise ModuleNotFoundError(f"No module named {name!r}")
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
-    with pytest.raises(ModuleNotFoundError, match=r"whoosh3\[mcp\]"):
-        build_mcp_server(SearchCore.build())
+    server = build_mcp_server(SearchCore.build())
+    assert server.name == "whoosh-search"
 
 
 def test_main_missing_corpus_files_returns_error(tmp_path, capsys):
@@ -106,16 +128,9 @@ def test_main_missing_corpus_files_returns_error(tmp_path, capsys):
 
 
 def test_main_without_sdk_prints_clean_message_and_exits_1(monkeypatch, capsys):
-    # When the optional 'mcp' SDK is absent, `whoosh-mcp` should print a single
+    # When no MCP SDK is installed, `whoosh-mcp` should print a single
     # actionable line (no chained traceback) and exit 1.
-    real_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "mcp" or name.startswith("mcp."):
-            raise ModuleNotFoundError("No module named 'mcp'")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
+    _block_mcp_sdks(monkeypatch)
     rc = main([])
     assert rc == 1
     err = capsys.readouterr().err


### PR DESCRIPTION
## What & why

PR #112 (thanks @mayuriphad) moved `whoosh.mcp` to the MCP Python SDK **2.x** (`mcp.server.MCPServer`) and pinned the `mcp` extra to `mcp>=2`. That's the right default, but it **breaks environments still on SDK 1.x** and doesn't cover the popular standalone [FastMCP](https://github.com/jlowin/fastmcp) 2.x package.

Whoosh only touches the small, stable `Server("name")` / `@server.tool()` / `server.run()` surface, which is identical across all three. So instead of pinning to one, `build_mcp_server()` now resolves the server class from whichever SDK is installed, in order:

1. **official SDK 2.x** — `mcp.server.MCPServer`
2. **official SDK 1.x** — `mcp.server.fastmcp.FastMCP`
3. **standalone FastMCP 2.x** — `fastmcp.FastMCP`

## Changes

- `whoosh.mcp._load_mcp_server_class()` — new loader with the try-order above; `build_mcp_server()` uses it.
- `pyproject.toml` — `mcp` extra unpinned back to `mcp>=1` (both majors work); new `fastmcp` extra installs the standalone package.
- "No SDK installed" error now points at both `whoosh3[mcp]` and `whoosh3[fastmcp]`.
- Tests: added a standalone-FastMCP fallback test and a shared `_block_mcp_sdks` helper; the existing behaviour tests still pass.
- README + CHANGELOG updated.

## Verification

- `pytest` → 866 passed, 4 skipped (optional deps absent in CI-less env).
- `ruff check` / `ruff format --check` clean; `python -m build` + `twine check` pass.

Builds on #112 rather than reverting it — 2.x stays the default, 1.x keeps working, and FastMCP is now a first-class option. Refs #111, #112.