### PR TITLE
Enable many ruff rules

### DIFF
--- a/examples/static_site_search.py
+++ b/examples/static_site_search.py
@@ -62,11 +62,7 @@ def build_index(directory, indexdir="site_index"):
     with ix.writer() as writer:
         for root, dirs, files in os.walk(directory):
             for file in files:
-                if (
-                    file.endswith(".md")
-                    or file.endswith(".rst")
-                    or file.endswith(".txt")
-                ):
+                if file.endswith((".md", ".rst", ".txt")):
                     filepath = os.path.join(root, file)
                     with open(filepath, encoding="utf-8", errors="ignore") as f:
                         content = f.read()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,13 +78,18 @@ lint.select = [
   "INT",    # flake8-gettext
   "LOG",    # flake8-logging
   "NPY",    # NumPy-specific rules
+  "PD",     # pandas-vet
   "PERF",   # Perflint
+  "PGH",    # pygrep-hooks
+  "PIE",    # flake8-pie
   "PLC",    # Pylint conventions
   "PLE",    # Pylint errors
   "PLR091", # Pylint Refactor just for max-args, max-branches, etc.
   "PYI",    # flake8-pyi
   "Q",      # flake8-quotes
+  "RSE",    # flake8-raise
   "SLOT",   # flake8-slots
+  "T10",    # flake8-debugger
   "TCH",    # flake8-type-checking
   "TID",    # flake8-tidy-imports
   "UP",     # pyupgrade
@@ -106,19 +111,14 @@ lint.select = [
   # "INP",  # flake8-no-pep420
   # "ISC",  # flake8-implicit-str-concat
   # "N",    # pep8-naming
-  # "PD",   # pandas-vet
-  # "PGH",  # pygrep-hooks
-  # "PIE",  # flake8-pie
   # "PL",   # Pylint
   # "PT",   # flake8-pytest-style
   # "PTH",  # flake8-use-pathlib
   # "RET",  # flake8-return
-  # "RSE",  # flake8-raise
   # "RUF",  # Ruff-specific rules
   # "S",    # flake8-bandit
   # "SIM",  # flake8-simplify
   # "SLF",  # flake8-self
-  # "T10",  # flake8-debugger
   # "T20",  # flake8-print
   # "TD",   # flake8-todos
   # "TRY",  # tryceratops
@@ -132,6 +132,7 @@ lint.ignore = [
   "F401",    # unused imports are often used for type-checking or optional features
   "FLY002",
   "PERF203",
+  "PIE790",  # Unnecessary `pass` statement
   # Whoosh deliberately uses function-local (lazy) imports throughout to avoid
   # circular imports between tightly-coupled modules and to defer loading of
   # optional/heavy dependencies until they are actually needed. These are an
@@ -148,9 +149,9 @@ lint.ignore = [
   "TC003",   # move std-library import into a type-checking block
   "UP031",
 ]
-lint.per-file-ignores."src/whoosh/compat.py" = [ "F821" ]
+lint.per-file-ignores."benchmark/enron.py" = [ "PGH003" ]
 lint.per-file-ignores."src/whoosh/filedb/filestore.py" = [ "UP024" ]
-lint.per-file-ignores."src/whoosh/util/__init__.py" = [ "F821" ]
+lint.per-file-ignores."src/whoosh/support/bench.py" = [ "PGH003" ]
 lint.mccabe.max-complexity = 45  # Default is 10
 lint.pylint.max-args = 22  # Default is 5
 lint.pylint.max-branches = 79  # Default is 12

--- a/src/whoosh/analysis/ngrams.py
+++ b/src/whoosh/analysis/ngrams.py
@@ -95,7 +95,7 @@ class NgramTokenizer(Tokenizer):
 
         if mode == "query":
             size = min(self.max, inlen)
-            for start in range(0, inlen - size + 1):
+            for start in range(inlen - size + 1):
                 end = start + size
                 if end > inlen:
                     continue
@@ -111,7 +111,7 @@ class NgramTokenizer(Tokenizer):
                 yield t
                 pos += 1
         else:
-            for start in range(0, inlen - self.min + 1):
+            for start in range(inlen - self.min + 1):
                 for size in range(self.min, self.max + 1):
                     end = start + size
                     if end > inlen:
@@ -201,7 +201,7 @@ class NgramFilter(Filter):
                         t.startchar = t.endchar - size
                     yield t
                 else:
-                    for start in range(0, len(text) - size + 1):
+                    for start in range(len(text) - size + 1):
                         t.text = text[start : start + size]
                         if chars:
                             t.startchar = startchar + start
@@ -226,7 +226,7 @@ class NgramFilter(Filter):
                             t.startchar = original_startchar + i
                         yield t
                 else:
-                    for start in range(0, len(text) - self.min + 1):
+                    for start in range(len(text) - self.min + 1):
                         for size in range(self.min, self.max + 1):
                             end = start + size
                             if end > len(text):

--- a/src/whoosh/codec/whoosh2.py
+++ b/src/whoosh/codec/whoosh2.py
@@ -162,7 +162,7 @@ class HashWriter:
         directory = self.directory = []
 
         pos = dbfile.tell()
-        for i in range(0, 256):
+        for i in range(256):
             entries = hashes[i]
             numslots = 2 * len(entries)
             directory.append((pos, numslots))
@@ -2139,7 +2139,7 @@ class OLD_DATETIME(OLD_NUMERIC):
             if isinstance(x, datetime):
                 x = datetime_to_long(x)
             elif not isinstance(x, int):
-                raise TypeError()
+                raise TypeError
         except ValueError:
             raise ValueError(f"DATETIME.to_text can't convert from {x!r}")
 

--- a/src/whoosh/filedb/compound.py
+++ b/src/whoosh/filedb/compound.py
@@ -176,7 +176,7 @@ class CompoundStorage(FileStorage):
 
         # Copy the files into the compound file
         for name in names:
-            if name.endswith(".toc") or name.endswith(".seg"):
+            if name.endswith((".toc", ".seg")):
                 raise Exception(name)
 
         for name in names:

--- a/src/whoosh/filedb/filewriting.py
+++ b/src/whoosh/filedb/filewriting.py
@@ -206,7 +206,7 @@ class SegmentWriter(SegmentDeletionMixin, IndexWriter):
         name2num = schema.name_to_number
 
         # Sort the keys by their order in the schema
-        fieldnames = [name for name in fields.keys() if not name.startswith("_")]
+        fieldnames = [name for name in fields if not name.startswith("_")]
         fieldnames.sort(key=name2num)
 
         # Check if the caller gave us a bogus field

--- a/src/whoosh/lang/lovins.py
+++ b/src/whoosh/lang/lovins.py
@@ -174,7 +174,7 @@ def a(base):
 
 def b(base):
     # b  Minimum stem length = 3 and do not remove ending after met or ryst
-    return len(base) > 2 and not (base.endswith("met") or base.endswith("ryst"))
+    return len(base) > 2 and not base.endswith(("met", "ryst"))
 
 
 def c(base):

--- a/src/whoosh/lang/morph_en.py
+++ b/src/whoosh/lang/morph_en.py
@@ -1097,7 +1097,7 @@ rules = (
 
 _partition_size = 20
 _partitions = []
-for p in range(0, len(rules) // _partition_size + 1):
+for p in range(len(rules) // _partition_size + 1):
     start = p * _partition_size
     end = (p + 1) * _partition_size
     pattern = "|".join(f"(?P<_g{i}>{r[0]})$" for i, r in enumerate(rules[start:end]))

--- a/src/whoosh/lang/porter2.py
+++ b/src/whoosh/lang/porter2.py
@@ -20,7 +20,7 @@ s1b_exp = re.compile(r"[aeiouy]")
 
 def get_r1(word):
     # exceptional forms
-    if word.startswith("gener") or word.startswith("arsen"):
+    if word.startswith(("gener", "arsen")):
         return 5
     if word.startswith("commun"):
         return 6
@@ -79,12 +79,12 @@ def step_0(word):
 def step_1a(word):
     if word.endswith("sses"):
         return word[:-4] + "ss"
-    if word.endswith("ied") or word.endswith("ies"):
+    if word.endswith(("ied", "ies")):
         if len(word) > 4:
             return word[:-3] + "i"
         else:
             return word[:-3] + "ie"
-    if word.endswith("us") or word.endswith("ss"):
+    if word.endswith(("us", "ss")):
         return word
     if word.endswith("s"):
         preceding = word[:-1]
@@ -105,7 +105,7 @@ def ends_with_double(word):
 
 
 def step_1b_helper(word):
-    if word.endswith("at") or word.endswith("bl") or word.endswith("iz"):
+    if word.endswith(("at", "bl", "iz")):
         return word + "e"
     if ends_with_double(word):
         return word[:-1]
@@ -254,7 +254,7 @@ def step_4(word, r2):
                 return word[: -len(end)]
             return word
 
-    if word.endswith("sion") or word.endswith("tion"):
+    if word.endswith(("sion", "tion")):
         if len(word) - 3 >= r2:
             return word[:-3]
 

--- a/src/whoosh/qparser/syntax.py
+++ b/src/whoosh/qparser/syntax.py
@@ -414,8 +414,7 @@ class OrGroup(GroupNode):
     def factory(cls, scale=1.0):
         class ScaledOrGroup(OrGroup):
             def __init__(self, nodes=None, **kwargs):
-                if "scale" in kwargs:
-                    del kwargs["scale"]
+                kwargs.pop("scale", None)
                 super().__init__(nodes=nodes, scale=scale, **kwargs)
 
         return ScaledOrGroup

--- a/src/whoosh/support/bitvector.py
+++ b/src/whoosh/support/bitvector.py
@@ -334,13 +334,13 @@ class BitVector:
 
     def __iter__(self):
         get = self.__getitem__
-        for i in range(0, self.size):
+        for i in range(self.size):
             if get(i):
                 yield i
 
     def __str__(self):
         get = self.__getitem__
-        return "".join("1" if get(i) else "0" for i in range(0, self.size))
+        return "".join("1" if get(i) else "0" for i in range(self.size))
 
     def __nonzero__(self):
         return self.count() > 0

--- a/src/whoosh/util/testing.py
+++ b/src/whoosh/util/testing.py
@@ -105,9 +105,7 @@ class TempIndex(TempStorage):
 def is_abstract_method(attr):
     """Returns True if the given object has __isabstractmethod__ == True."""
 
-    return hasattr(attr, "__isabstractmethod__") and getattr(
-        attr, "__isabstractmethod__"
-    )
+    return hasattr(attr, "__isabstractmethod__") and attr.__isabstractmethod__
 
 
 def check_abstract_methods(base, subclass):

--- a/src/whoosh/util/times.py
+++ b/src/whoosh/util/times.py
@@ -143,7 +143,7 @@ class adatetime:
             self.microsecond = microsecond
 
     def __eq__(self, other):
-        if not other.__class__ is self.__class__:
+        if other.__class__ is not self.__class__:
             if not is_ambiguous(self) and isinstance(other, datetime):
                 return fix(self) == other
             else:
@@ -325,7 +325,7 @@ class timespan:
         self.end = copy.copy(end)
 
     def __eq__(self, other):
-        if not other.__class__ is self.__class__:
+        if other.__class__ is not self.__class__:
             return False
         return self.start == other.start and self.end == other.end
 

--- a/src/whoosh/writing.py
+++ b/src/whoosh/writing.py
@@ -785,9 +785,7 @@ class SegmentWriter(IndexWriter):
         add_post = self.pool.add
 
         docboost = self._doc_boost(fields)
-        fieldnames = sorted(
-            [name for name in fields.keys() if not name.startswith("_")]
-        )
+        fieldnames = sorted([name for name in fields if not name.startswith("_")])
         self._check_fields(schema, fieldnames)
 
         perdocwriter.start_doc(docnum)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -264,9 +264,9 @@ def test_word_segments():
 def test_biword():
     ana = analysis.RegexTokenizer(r"\w+") | analysis.BiWordFilter()
     result = [t.copy() for t in ana("the sign of four", chars=True, positions=True)]
-    assert ["the-sign", "sign-of", "of-four"] == [t.text for t in result]
-    assert [(0, 8), (4, 11), (9, 16)] == [(t.startchar, t.endchar) for t in result]
-    assert [0, 1, 2] == [t.pos for t in result]
+    assert [t.text for t in result] == ["the-sign", "sign-of", "of-four"]
+    assert [(t.startchar, t.endchar) for t in result] == [(0, 8), (4, 11), (9, 16)]
+    assert [t.pos for t in result] == [0, 1, 2]
 
     result = [t.copy() for t in ana("single")]
     assert len(result) == 1
@@ -343,7 +343,7 @@ def test_double_metaphone():
     }
 
     dmn = name = None
-    for name in names.keys():
+    for name in names:
         dmn = double_metaphone(name)
     assert dmn == names[name]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -885,7 +885,7 @@ def test_search_files_with_matches_prints_paths(corpus, capsys):
     lines = out.splitlines()
     assert len(lines) == 2
     for line in lines:
-        assert line.endswith(".txt") or line.endswith(".md") or line.endswith(".rst")
+        assert line.endswith((".txt", ".md", ".rst"))
     assert "alpha.txt" in out
     assert "beta.md" in out
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -265,7 +265,7 @@ def test_numeric_ranges():
         # Note that range() is always inclusive-exclusive
         check("[10 to 390]", list(range(10, 390 + 1)))
         check("[100 to]", list(range(100, 400)))
-        check("[to 350]", list(range(0, 350 + 1)))
+        check("[to 350]", list(range(350 + 1)))
         check("[16 to 255]", list(range(16, 255 + 1)))
         check("{10 to 390]", list(range(11, 390 + 1)))
         check("[10 to 390}", list(range(10, 390)))

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -149,9 +149,9 @@ def test_lengths():
         w.commit()
 
         with ix.reader() as dr:
-            ls1 = [dr.doc_field_length(i, "f1") for i in range(0, len(lengths))]
+            ls1 = [dr.doc_field_length(i, "f1") for i in range(len(lengths))]
             assert ls1 == [0] * len(lengths)
-            ls2 = [dr.doc_field_length(i, "f2") for i in range(0, len(lengths))]
+            ls2 = [dr.doc_field_length(i, "f2") for i in range(len(lengths))]
             assert ls2 == [byte_to_length(length_to_byte(l)) for l in lengths]
 
 

--- a/tests/test_searching.py
+++ b/tests/test_searching.py
@@ -883,7 +883,7 @@ def test_finalweighting():
         q = qparser.QueryParser("summary", None).parse("alfa OR bravo")
         r = s.search(q)
         ids = [fs["id"] for fs in r]
-        assert ["2", "4", "1", "3"] == ids
+        assert ids == ["2", "4", "1", "3"]
 
 
 def test_outofdate():


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

% `ruff check --select=E714,B009,PIE808,RSE102,RUF019,RUF051,SIM118,SIM300 --fix`

% `ruff rule SIM118 ` # in-dict-keys is conservative, so 4 of those issues are still in the codebase.

Also manually fix `ruff rule PIE810 ` # multiple-starts-ends-with

## Related issues

<!-- e.g. Fixes #123 -->

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [x] Added/updated tests for the change where it makes sense
- [ ] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](https://github.com/priya-sundaram-dev/whoosh/blob/main/CONTRIBUTING.md) guide
