### PR TITLE
Ruff rules E for pycodestyle errors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,7 +98,7 @@ pygments_style = "sphinx"
 
 # -- Options for sphinx_rtd_theme -----------------------------------------
 # https://github.com/snide/sphinx_rtd_theme
-import sphinx_rtd_theme
+import sphinx_rtd_theme  # noqa: E402
 
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ lint.select = [
   "C90",    # McCabe cyclomatic complexity
   "DJ",     # flake8-django
   "DTZ",    # flake8-datetimez
+  "E",      # pycodestyle
   "EXE",    # flake8-executable
   "F",      # Pyflakes
   "FA",     # flake8-future-annotations
@@ -102,7 +103,6 @@ lint.select = [
   # "COM",  # flake8-commas
   # "CPY",  # flake8-copyright
   # "D",    # pydocstyle
-  # "E",    # pycodestyle
   # "EM",   # flake8-errmsg
   # "ERA",  # eradicate
   # "FBT",  # flake8-boolean-trap
@@ -129,6 +129,7 @@ lint.ignore = [
   # store tz-naive values and callers control any tz handling. Requiring an explicit
   # tzinfo everywhere would be incorrect for this library's supported data model.
   "DTZ",     # flake8-datetimez (naive datetimes are a supported feature)
+  "E501",    # line-length is enforced by ruff format, not ruff check
   "F401",    # unused imports are often used for type-checking or optional features
   "FLY002",
   "PERF203",

--- a/src/whoosh/classify.py
+++ b/src/whoosh/classify.py
@@ -239,7 +239,9 @@ def simhash(features, hashbits=32):
     if hashbits == 32:
         hashfn = hash
     else:
-        hashfn = lambda s: _hash(s, hashbits)
+
+        def hashfn(s):
+            return _hash(s, hashbits)
 
     vs = [0] * hashbits
     for feature, weight in features:

--- a/src/whoosh/codec/base.py
+++ b/src/whoosh/codec/base.py
@@ -186,9 +186,9 @@ class FieldWriter:
             get_dfl_reader = getattr(lengths, "doc_field_length_reader", None)
             if get_dfl_reader is None:
                 plain_dfl = lengths.doc_field_length
-                get_dfl_reader = lambda fieldname: (
-                    lambda docnum, _fn=fieldname: plain_dfl(docnum, _fn)
-                )
+
+                def get_dfl_reader(fieldname):
+                    return lambda docnum, _fn=fieldname: plain_dfl(docnum, _fn)
         else:
             get_dfl_reader = None
         # Per-field bound length accessor, (re)bound whenever the field
@@ -227,7 +227,9 @@ class FieldWriter:
                 if get_dfl_reader is not None:
                     field_dfl = get_dfl_reader(fieldname)
                 else:
-                    field_dfl = lambda docnum: 0
+
+                    def field_dfl(docnum):
+                        return 0
 
             # HACK: items where docnum == -1 indicate words that should be added
             # to the spelling graph, not the postings

--- a/src/whoosh/codec/plaintext.py
+++ b/src/whoosh/codec/plaintext.py
@@ -89,12 +89,12 @@ class LineReader:
     def _parse_line(self, line):
         line = line.decode("latin1")
         line = line.rstrip()
-        l = len(line)
+        length = len(line)
         line = line.lstrip()
         if not line or line.startswith("#"):
             return None
 
-        indent = (l - len(line)) // 2
+        indent = (length - len(line)) // 2
 
         parts = line.split("\t")
         command = parts[0]

--- a/src/whoosh/codec/whoosh2.py
+++ b/src/whoosh/codec/whoosh2.py
@@ -1975,7 +1975,7 @@ def deminimize_values(postingsize, count, string, compression=0):
 
 # Legacy field types
 
-from whoosh.fields import NUMERIC
+from whoosh.fields import NUMERIC  # noqa: E402
 
 
 class OLD_NUMERIC(NUMERIC):
@@ -2183,7 +2183,7 @@ class OLD_DATETIME(OLD_NUMERIC):
 
         try:
             at = self._parse_datestring(qstring)
-        except:
+        except:  # noqa: E722
             e = sys.exc_info()[1]
             return query.error_query(e)
 
@@ -2249,7 +2249,7 @@ def text_to_float(text, signed=True):
 
 # Functions for converting sortable representations to and from text.
 
-from whoosh.support.base85 import from_base85, to_base85
+from whoosh.support.base85 import from_base85, to_base85  # noqa: E402
 
 
 def sortable_int_to_text(x, shift=0):

--- a/src/whoosh/fields.py
+++ b/src/whoosh/fields.py
@@ -1008,7 +1008,7 @@ class DATETIME(NUMERIC):
 
         try:
             at = self._parse_datestring(qstring)
-        except:
+        except:  # noqa: E722
             e = sys.exc_info()[1]
             return query.error_query(e)
 
@@ -1642,7 +1642,7 @@ class Schema:
         if type(fieldtype) is type:
             try:
                 fieldtype = fieldtype()
-            except:
+            except:  # noqa: E722
                 e = sys.exc_info()[1]
                 raise FieldConfigurationError(
                     f"Error: {e} instantiating field {name!r}: {fieldtype!r}"

--- a/src/whoosh/filedb/filepostings.py
+++ b/src/whoosh/filedb/filepostings.py
@@ -218,7 +218,7 @@ class FilePostingWriter(PostingWriter):
             lens = [dfl_fn(id, fieldnum) for id in ids]
             minlength = min(lens)
             assert minlength > 0
-            maxwol = max(w / l for w, l in zip(weights, lens))
+            maxwol = max(w / l for w, l in zip(weights, lens))  # noqa: E741
 
         blockinfo_start = pf.tell()
         blockinfo = BlockInfo(

--- a/src/whoosh/filedb/misc.py
+++ b/src/whoosh/filedb/misc.py
@@ -40,13 +40,25 @@ def decode_termkey(key):
 
 _terminfo_struct = Struct("!III")  # frequency, offset, postcount
 _pack_terminfo = _terminfo_struct.pack
-encode_terminfo = lambda cf_offset_df: _pack_terminfo(*cf_offset_df)
+
+
+def encode_terminfo(cf_offset_df):
+    return _pack_terminfo(*cf_offset_df)
+
+
 decode_terminfo = _terminfo_struct.unpack
 
 encode_docnum = pack_uint
-decode_docnum = lambda x: unpack_uint(x)[0]
 
-enpickle = lambda data: dumps(data, -1)
+
+def decode_docnum(x):
+    return unpack_uint(x)[0]
+
+
+def enpickle(data):
+    return dumps(data, -1)
+
+
 depickle = loads
 
 enmarshal = mdumps

--- a/src/whoosh/filedb/structfile.py
+++ b/src/whoosh/filedb/structfile.py
@@ -165,26 +165,26 @@ class StructFile:
         return self.read(self.read_varint())
 
     def read_string2(self):
-        l = self.read_ushort()
-        return self.read(l)
+        line = self.read_ushort()
+        return self.read(line)
 
     def read_string4(self):
-        l = self.read_int()
-        return self.read(l)
+        line = self.read_int()
+        return self.read(line)
 
     def get_string2(self, pos):
-        l = self.get_ushort(pos)
+        line = self.get_ushort(pos)
         base = pos + _SHORT_SIZE
-        return self.get(base, l), base + l
+        return self.get(base, line), base + line
 
     def get_string4(self, pos):
-        l = self.get_int(pos)
+        line = self.get_int(pos)
         base = pos + _INT_SIZE
-        return self.get(base, l), base + l
+        return self.get(base, line), base + line
 
     def skip_string(self):
-        l = self.read_varint()
-        self.seek(l, 1)
+        line = self.read_varint()
+        self.seek(line, 1)
 
     def write_varint(self, i):
         """Writes a variable-length unsigned integer to the wrapped file."""

--- a/src/whoosh/lang/lovins.py
+++ b/src/whoosh/lang/lovins.py
@@ -50,7 +50,7 @@ def H(base):
     return c2 == "t" or (c2 == "l" and c1 == "l")
 
 
-def I(base):
+def I(base):  # noqa: E743
     # I  Do not remove ending after o or e
     c = base[-1]
     return c != "o" and c != "e"
@@ -86,7 +86,7 @@ def N(base):
     return len(base) > 3 or (len(base) == 3 and base[-1] != "s")
 
 
-def O(base):
+def O(base):  # noqa: E743
     # O  Remove ending only after l or i
     c = base[-1]
     return c == "l" or c == "i"

--- a/src/whoosh/qparser/dateparse.py
+++ b/src/whoosh/qparser/dateparse.py
@@ -697,10 +697,14 @@ class English(DateParser):
             ),
         )
 
-        midnight_l = lambda p, dt: adatetime(hour=0, minute=0, second=0, microsecond=0)
+        def midnight_l(p, dt):
+            return adatetime(hour=0, minute=0, second=0, microsecond=0)
+
         midnight = Regex("midnight", midnight_l)
 
-        noon_l = lambda p, dt: adatetime(hour=12, minute=0, second=0, microsecond=0)
+        def noon_l(p, dt):
+            return adatetime(hour=12, minute=0, second=0, microsecond=0)
+
         noon = Regex("noon", noon_l)
 
         now = Regex("now", lambda p, dt: dt)

--- a/src/whoosh/qparser/default.py
+++ b/src/whoosh/qparser/default.py
@@ -229,7 +229,7 @@ class QueryParser:
                 try:
                     q = field.parse_query(fieldname, text, boost=boost)
                     return q
-                except:
+                except:  # noqa: E722
                     e = sys.exc_info()[1]
                     return query.error_query(e)
 

--- a/src/whoosh/query/compound.py
+++ b/src/whoosh/query/compound.py
@@ -266,7 +266,10 @@ class And(CompoundQuery):
 
     def _matcher(self, subs, searcher, context):
         r = searcher.reader()
-        q_weight_fn = lambda q: 0 - q.estimate_size(r)
+
+        def q_weight_fn(q):
+            return 0 - q.estimate_size(r)
+
         return self._tree_matcher(
             subs, matching.IntersectionMatcher, searcher, context, q_weight_fn
         )
@@ -379,7 +382,10 @@ class DefaultOr(Or):
 
     def _matcher(self, subs, searcher, context):
         reader = searcher.reader()
-        q_weight_fn = lambda q: q.estimate_size(reader)
+
+        def q_weight_fn(q):
+            return q.estimate_size(reader)
+
         m = self._tree_matcher(
             subs, matching.UnionMatcher, searcher, context, q_weight_fn
         )
@@ -491,7 +497,10 @@ class DisjunctionMax(CompoundQuery):
 
     def _matcher(self, subs, searcher, context):
         r = searcher.reader()
-        q_weight_fn = lambda q: q.estimate_size(r)
+
+        def q_weight_fn(q):
+            return q.estimate_size(r)
+
         return self._tree_matcher(
             subs,
             matching.DisjunctionMaxMatcher,

--- a/src/whoosh/support/base85.py
+++ b/src/whoosh/support/base85.py
@@ -48,8 +48,8 @@ def from_base85(text):
 
 
 def b85encode(text, pad=False):
-    l = len(text)
-    if r := l % 4:
+    length = len(text)
+    if r := length % 4:
         text += "\0" * (4 - r)
     longs = len(text) >> 2
     out = []
@@ -66,15 +66,15 @@ def b85encode(text, pad=False):
         return out
 
     # Trim padding
-    olen = l % 4
+    olen = length % 4
     if olen:
         olen += 1
-    olen += l / 4 * 5
+    olen += length // 4 * 5
     return out[0:olen]
 
 
 def b85decode(text):
-    l = len(text)
+    length = len(text)
     out = []
     for i in range(0, len(text), 5):
         chunk = text[i : i + 5]
@@ -89,14 +89,14 @@ def b85decode(text):
         out.append(acc)
 
     # Pad final chunk if necessary
-    cl = l % 5
+    cl = length % 5
     if cl:
         acc *= 85 ** (5 - cl)
         if cl > 1:
             acc += 0xFFFFFF >> (cl - 2) * 8
         out[-1] = acc
 
-    out = struct.pack(">" + "L" * ((l + 4) / 5), *out)
+    out = struct.pack(">" + "L" * ((length + 4) / 5), *out)
     if cl:
         out = out[: -(5 - cl)]
 

--- a/src/whoosh/support/relativedelta.py
+++ b/src/whoosh/support/relativedelta.py
@@ -458,7 +458,7 @@ class relativedelta:
         return self.__mul__(1 / float(other))
 
     def __repr__(self):
-        l = []
+        lst = []
         for attr in [
             "years",
             "months",
@@ -471,7 +471,7 @@ class relativedelta:
         ]:
             value = getattr(self, attr)
             if value:
-                l.append("%s=%+d" % (attr, value))
+                lst.append("%s=%+d" % (attr, value))
         for attr in [
             "year",
             "month",
@@ -484,8 +484,8 @@ class relativedelta:
         ]:
             value = getattr(self, attr)
             if value is not None:
-                l.append(f"{attr}={repr(value)}")
-        return f"{self.__class__.__name__}({', '.join(l)})"
+                lst.append(f"{attr}={repr(value)}")
+        return f"{self.__class__.__name__}({', '.join(lst)})"
 
 
 # vim:ts=4:sw=4:et

--- a/src/whoosh/util/filelock.py
+++ b/src/whoosh/util/filelock.py
@@ -70,7 +70,7 @@ class LockBase:
         if hasattr(self, "fd") and self.fd:
             try:
                 self.release()
-            except:
+            except Exception:
                 pass
 
     def acquire(self, blocking=False):

--- a/src/whoosh/util/numeric.py
+++ b/src/whoosh/util/numeric.py
@@ -202,7 +202,9 @@ def split_ranges(intsize, step, start, end):
     while True:
         diff = 1 << (shift + step)
         mask = ((1 << step) - 1) << shift
-        setbits = lambda x: x | ((1 << shift) - 1)
+
+        def setbits(x):
+            return x | ((1 << shift) - 1)
 
         haslower = (start & mask) != 0
         hasupper = (end & mask) != mask

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -747,7 +747,7 @@ def test_add_reader_to_index():
     writer.add_reader(reader)
 
     # Assert that the reader was added to the index
-    assert writer._added == True
+    assert writer._added
 
 
 # If term not found, a TermNotFound exception should be raised

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -239,11 +239,11 @@ def test_column_field():
 
             cra = r.column_reader("a")
             assert cra[0] == "alfa bravo"
-            assert type(cra[0]) == str
+            assert type(cra[0]) is str
 
             crb = r.column_reader("b")
             assert crb[0] == cd
-            assert type(crb[0]) == bytes
+            assert type(crb[0]) is bytes
 
 
 def test_column_query():
@@ -356,7 +356,10 @@ def test_varbytes_offsets():
 # Initializes the 'fieldname' and 'condition' attributes with the values passed as parameters.
 def test_initializes_fieldname_and_condition_attributes():
     fieldname = "test_field"
-    condition = lambda x: x > 0
+
+    def condition(x):
+        return x > 0
+
     query = ColumnQuery(fieldname, condition)
     assert query.fieldname == fieldname
     assert query.condition == condition
@@ -365,7 +368,10 @@ def test_initializes_fieldname_and_condition_attributes():
 # If 'condition' is a callable, sets it as the 'condition' attribute.
 def test_sets_condition_attribute_if_condition_is_callable():
     fieldname = "test_field"
-    condition = lambda x: x > 0
+
+    def condition(x):
+        return x > 0
+
     query = ColumnQuery(fieldname, condition)
     assert query.condition == condition
 
@@ -381,7 +387,10 @@ def test_creates_lambda_function_if_condition_is_not_callable():
 # If 'fieldname' is not a string, it should not raise a TypeError.
 def test_raises_typeerror_if_fieldname_is_not_string():
     fieldname = 10
-    condition = lambda x: x > 0
+
+    def condition(x):
+        return x > 0
+
     query = ColumnQuery(fieldname, condition)
     assert query.fieldname == fieldname
     assert query.condition == condition
@@ -399,7 +408,10 @@ def test_behavior_if_condition_is_not_callable_and_not_hashable():
 # If 'condition' is a callable and it raises an exception when called with a document value, raises that exception.
 def test_raises_exception_if_condition_callable_raises_exception():
     fieldname = "test_field"
-    condition = lambda x: 1 / x
+
+    def condition(x):
+        return 1 / x
+
     with pytest.raises(ZeroDivisionError):
         query = ColumnQuery(fieldname, condition)
         query.condition(0)
@@ -408,7 +420,10 @@ def test_raises_exception_if_condition_callable_raises_exception():
 # If 'condition' is a callable and it returns a non-boolean value when called with a document value, does not raise a TypeError.
 def test_does_not_raise_typeerror_if_condition_callable_returns_non_boolean_value():
     fieldname = "test_field"
-    condition = lambda x: "True"
+
+    def condition(x):
+        return "True"
+
     query = ColumnQuery(fieldname, condition)
     assert isinstance(query, ColumnQuery)
 
@@ -418,7 +433,10 @@ def test_returns_constantscorematcher_matching_all_documents_if_condition_callab
     from unittest.mock import Mock
 
     fieldname = "test_field"
-    condition = lambda x: True
+
+    def condition(x):
+        return True
+
     query = ColumnQuery(fieldname, condition)
     searcher = Mock()
     creader = Mock()
@@ -434,7 +452,10 @@ def test_matcher_initialization_may_take_long_time_if_condition_callable_is_very
     from unittest.mock import Mock, patch
 
     fieldname = "test_field"
-    condition = lambda x: time.sleep(10)
+
+    def condition(x):
+        return time.sleep(10)
+
     query = ColumnQuery(fieldname, condition)
     searcher = Mock()
     searcher.reader.return_value.has_column.return_value = True
@@ -445,7 +466,9 @@ def test_matcher_initialization_may_take_long_time_if_condition_callable_is_very
 
 # Initializes the '_i' attribute to 0.
 def test_initializes_i_attribute_to_0():
-    condition = lambda x: x > 0
+    def condition(x):
+        return x > 0
+
     creader = []  # Define creader variable
     matcher = ColumnMatcher(creader, condition)
     assert matcher._i == 0
@@ -453,7 +476,9 @@ def test_initializes_i_attribute_to_0():
 
 # Initializes the 'creader' attribute with the value passed as parameter.
 def test_initializes_creader_attribute():
-    condition = lambda x: x > 0
+    def condition(x):
+        return x > 0
+
     creader = [1, 2, 3, 4, 5]
     matcher = ColumnMatcher(creader, condition)
     assert matcher.creader == creader
@@ -461,7 +486,9 @@ def test_initializes_creader_attribute():
 
 # Initializes the 'condition' attribute with the value passed as parameter.
 def test_initializes_condition_attribute():
-    condition = lambda x: x > 0
+    def condition(x):
+        return x > 0
+
     creader = []
     matcher = ColumnMatcher(creader, condition)
     assert matcher.condition == condition
@@ -469,24 +496,31 @@ def test_initializes_condition_attribute():
 
 # Returns True if the '_i' attribute is less than the length of the 'creader' attribute.
 def test_returns_true_if_i_attribute_is_less_than_length_of_creader_attribute():
-    condition = lambda x: x > 0
+    def condition(x):
+        return x > 0
+
     creader = [1, 2, 3, 4, 5]
     matcher = ColumnMatcher(creader, condition)
-    assert matcher.is_active() == True
+    assert matcher.is_active()
 
 
 # Returns False if the '_i' attribute is equal to or greater than the length of the 'creader' attribute.
 def test_returns_false_if_i_attribute_is_equal_to_or_greater_than_length_of_creader_attribute():
-    condition = lambda x: x > 0
+    def condition(x):
+        return x > 0
+
     creader = [1, 2, 3, 4, 5]
     matcher = ColumnMatcher(creader, condition)
     matcher._i = len(creader)
-    assert matcher.is_active() == False
+    assert not matcher.is_active()
 
 
 # test if the `is_leaf` function is True
 def test_is_leaf_true():
     fieldname = "test_field"
-    condition = lambda x: x > 0
+
+    def condition(x):
+        return x > 0
+
     query = ColumnQuery(fieldname, condition)
-    assert query.is_leaf() == True
+    assert query.is_leaf()

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -152,7 +152,7 @@ def test_lengths():
             ls1 = [dr.doc_field_length(i, "f1") for i in range(len(lengths))]
             assert ls1 == [0] * len(lengths)
             ls2 = [dr.doc_field_length(i, "f2") for i in range(len(lengths))]
-            assert ls2 == [byte_to_length(length_to_byte(l)) for l in lengths]
+            assert ls2 == [byte_to_length(length_to_byte(length)) for length in lengths]
 
 
 def test_many_lengths():

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -74,7 +74,8 @@ def test_wrapper():
 
 
 def test_filter():
-    lm = lambda: matching.ListMatcher(list(range(2, 10)))
+    def lm():
+        return matching.ListMatcher(list(range(2, 10)))
 
     fm = matching.FilterMatcher(lm(), frozenset([3, 9]))
     assert list(fm.all_ids()) == [3, 9]

--- a/tests/test_mpwriter.py
+++ b/tests/test_mpwriter.py
@@ -126,7 +126,7 @@ def test_no_add():
     schema = fields.Schema(text=fields.TEXT(stored=True, spelling=True, vector=True))
     with TempIndex(schema) as ix:
         with ix.writer(procs=3) as w:
-            assert type(w) == MpWriter
+            assert type(w) is MpWriter
 
 
 def _do_merge(writerclass):

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -442,7 +442,9 @@ def test_nested_parent_orphan_child_gh31():
             r = s.search(q, limit=None)
             return [hit["name"] for hit in r]
 
-    parent = lambda nm: {"kind": "parent", "name": nm}
+    def parent(nm):
+        return {"kind": "parent", "name": nm}
+
     match = {"kind": "child", "fn": "match"}
     nomatch = {"kind": "child", "fn": "nomatch"}
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -788,10 +788,10 @@ def test_valid_fieldname_start_end():
     assert nr.fieldname == "number"
     assert nr.start == 10
     assert nr.end == 5925
-    assert nr.startexcl == False
-    assert nr.endexcl == False
+    assert not nr.startexcl
+    assert not nr.endexcl
     assert nr.boost == 1.0
-    assert nr.constantscore == True
+    assert nr.constantscore
 
 
 # NumericRange with valid fieldname, start, end, startexcl=True, and endexcl=True
@@ -802,10 +802,10 @@ def test_valid_fieldname_start_end_startexcl_endexcl():
     assert nr.fieldname == "number"
     assert nr.start == 10
     assert nr.end == 5925
-    assert nr.startexcl == True
-    assert nr.endexcl == True
+    assert nr.startexcl
+    assert nr.endexcl
     assert nr.boost == 1.0
-    assert nr.constantscore == True
+    assert nr.constantscore
 
 
 # NumericRange with valid fieldname, start, end, boost=2.0, and constantscore=False
@@ -816,10 +816,10 @@ def test_valid_fieldname_start_end_boost_constantscore():
     assert nr.fieldname == "number"
     assert nr.start == 10
     assert nr.end == 5925
-    assert nr.startexcl == False
-    assert nr.endexcl == False
+    assert not nr.startexcl
+    assert not nr.endexcl
     assert nr.boost == 2.0
-    assert nr.constantscore == False
+    assert not nr.constantscore
 
 
 # NumericRange with valid fieldname, start=None, and end=None
@@ -830,10 +830,10 @@ def test_valid_fieldname_start_none_end_none():
     assert nr.fieldname == "number"
     assert nr.start == 0
     assert nr.end == 0
-    assert nr.startexcl == False
-    assert nr.endexcl == False
+    assert not nr.startexcl
+    assert not nr.endexcl
     assert nr.boost == 1.0
-    assert nr.constantscore == True
+    assert nr.constantscore
 
 
 # NumericRange with valid fieldname, start=0, and end=0
@@ -844,10 +844,10 @@ def test_valid_fieldname_start_zero_end_zero():
     assert nr.fieldname == "number"
     assert nr.start == 0
     assert nr.end == 0
-    assert nr.startexcl == False
-    assert nr.endexcl == False
+    assert not nr.startexcl
+    assert not nr.endexcl
     assert nr.boost == 1.0
-    assert nr.constantscore == True
+    assert nr.constantscore
 
 
 # NumericRange with valid fieldname, start=-1, and end=1
@@ -858,10 +858,10 @@ def test_valid_fieldname_start_minus_one_end_one():
     assert nr.fieldname == "number"
     assert nr.start == -1
     assert nr.end == 1
-    assert nr.startexcl == False
-    assert nr.endexcl == False
+    assert not nr.startexcl
+    assert not nr.endexcl
     assert nr.boost == 1.0
-    assert nr.constantscore == True
+    assert nr.constantscore
 
 
 # NumericRange with valid fieldname, start=1, and end=-1
@@ -872,10 +872,10 @@ def test_valid_fieldname_start_end_again():
     assert nr.fieldname == "fieldname"
     assert nr.start == 1
     assert nr.end == -1
-    assert nr.startexcl == False
-    assert nr.endexcl == False
+    assert not nr.startexcl
+    assert not nr.endexcl
     assert nr.boost == 1.0
-    assert nr.constantscore == True
+    assert nr.constantscore
 
 
 # NumericRange with valid fieldname, start=1.5, and end=2.5
@@ -886,10 +886,10 @@ def test_valid_fieldname_start_end_float():
     assert nr.fieldname == "fieldname"
     assert nr.start == 1.5
     assert nr.end == 2.5
-    assert nr.startexcl == False
-    assert nr.endexcl == False
+    assert not nr.startexcl
+    assert not nr.endexcl
     assert nr.boost == 1.0
-    assert nr.constantscore == True
+    assert nr.constantscore
 
 
 # NumericRange with valid fieldname, start=1.5, and end=2.5, startexcl=True, and endexcl=True
@@ -900,10 +900,10 @@ def test_valid_fieldname_start_end_excl():
     assert nr.fieldname == "fieldname"
     assert nr.start == 1.5
     assert nr.end == 2.5
-    assert nr.startexcl == True
-    assert nr.endexcl == True
+    assert nr.startexcl
+    assert nr.endexcl
     assert nr.boost == 1.0
-    assert nr.constantscore == True
+    assert nr.constantscore
 
 
 # NumericRange with valid fieldname, start=1.5, and end=2.5, boost=2.0, and constantscore=False
@@ -914,10 +914,10 @@ def test_valid_fieldname_start_end_boost_constantscore_again():
     assert nr.fieldname == "fieldname"
     assert nr.start == 1.5
     assert nr.end == 2.5
-    assert nr.startexcl == False
-    assert nr.endexcl == False
+    assert not nr.startexcl
+    assert not nr.endexcl
     assert nr.boost == 2.0
-    assert nr.constantscore == False
+    assert not nr.constantscore
 
 
 # NumericRange with invalid boost
@@ -943,10 +943,10 @@ def test_invalid_startexcl_valid_endexcl():
     assert nr.fieldname == "number"
     assert nr.start == 10
     assert nr.end == 5925
-    assert nr.startexcl == True
-    assert nr.endexcl == False
+    assert nr.startexcl
+    assert not nr.endexcl
     assert nr.boost == 1.0
-    assert nr.constantscore == True
+    assert nr.constantscore
 
 
 # NumericRange with invalid constantscore
@@ -964,8 +964,8 @@ def test_valid_startexcl_invalid_endexcl():
     from whoosh.query.ranges import NumericRange
 
     nr = NumericRange("number", 10, 5925, startexcl=True, endexcl=True)
-    assert nr.startexcl == True
-    assert nr.endexcl == True
+    assert nr.startexcl
+    assert nr.endexcl
 
 
 # NumbericRange with negative boost field
@@ -980,10 +980,10 @@ def test_numeric_range_with_negative_boost():
     assert nr.fieldname == "number"
     assert nr.start == 10
     assert nr.end == 5925
-    assert nr.startexcl == False
-    assert nr.endexcl == False
+    assert not nr.startexcl
+    assert not nr.endexcl
     assert nr.boost == -1.0
-    assert nr.constantscore == True
+    assert nr.constantscore
 
 
 def test_multiterm_boost_propagates_to_score():

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -211,7 +211,8 @@ def test_extend_filtered():
     w.add_document(id=5, text="foxtrot sierra tango")
     w.commit()
 
-    hits = lambda result: [hit["id"] for hit in result]
+    def hits(result):
+        return [hit["id"] for hit in result]
 
     with ix.searcher() as s:
         r1 = s.search(query.Term("text", "alfa"), filter={1, 4})

--- a/tests/test_searching.py
+++ b/tests/test_searching.py
@@ -1605,7 +1605,7 @@ def test_coord():
 
     with ix.searcher() as s:
         m = q.matcher(s)
-        assert type(m) == CoordMatcher
+        assert type(m) is CoordMatcher
 
         r = s.search(q, optimize=False)
         assert [hit["id"] for hit in r] == [4, 5, 3, 6, 1, 8, 2, 7]

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -694,7 +694,7 @@ def test_add_fail_with_absorbed_exception():
         try:
             # Integer value is invalid, but absorbed exception causes silent failure
             w.add_document(id=1)
-        except:
+        except Exception:
             pass
         with pytest.raises(Exception) as ex:
             w.add_document(id=2)


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

Fix https://docs.astral.sh/ruff/rules/#error-e

Before: 
% `ruff check --select=E --statistics`
```
493	E501	line-too-long
 42	E712	true-false-comparison
 28	E731	lambda-assignment
 11	E741	ambiguous-variable-name
  6	E722	bare-except
  4	E721	type-comparison
  3	E402	module-import-not-at-top-of-file
  2	E743	ambiguous-function-name
Found 589 errors.
No fixes available (70 hidden fixes can be enabled with the `--unsafe-fixes` option).
```

## Related issues

<!-- e.g. Fixes #123 -->

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [x] Added/updated tests for the change where it makes sense
- [ ] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](https://github.com/priya-sundaram-dev/whoosh/blob/main/CONTRIBUTING.md) guide
