### PR TITLE
ty: un-ignore empty-body and parameter-already-assigned rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,6 @@ warn_unused_ignores = true
 # parameter-already-assigned) are the smallest starting points.  Re-run
 # `ty check src/whoosh` with a rule flipped to "warn" to get a fresh count.
 rules.call-non-callable = "ignore"  # 20 instances
-rules.empty-body = "ignore"  # 1 instance
 rules.invalid-argument-type = "ignore"  # 30 instances
 rules.invalid-assignment = "ignore"  # 21 instances
 rules.invalid-ignore-comment = "ignore"  # 1 instance
@@ -199,7 +198,6 @@ rules.missing-argument = "ignore"  # 12 instances
 rules.no-matching-overload = "ignore"  # 2 instances
 rules.not-iterable = "ignore"  # 4 instances
 rules.not-subscriptable = "ignore"  # 15 instances
-rules.parameter-already-assigned = "ignore"  # 1 instance
 rules.too-many-positional-arguments = "ignore"  # 27 instances
 rules.unknown-argument = "ignore"  # 10 instances
 rules.unresolved-attribute = "ignore"  # 347 instances

--- a/src/whoosh/qparser/default.py
+++ b/src/whoosh/qparser/default.py
@@ -395,9 +395,6 @@ class QueryParser:
                 print_debug(debug, f"Normalized query: {q!r}")
         return q
 
-    def parse_(self, text: str, normalize: bool = True) -> query.Query:
-        pass
-
 
 # Premade parser configurations
 

--- a/src/whoosh/qparser/syntax.py
+++ b/src/whoosh/qparser/syntax.py
@@ -223,7 +223,6 @@ class GroupNode(SyntaxNode):
 
     def apply(self, fn):
         return self.__class__(
-            self.type,
             [fn(node) for node in self.nodes],
             boost=self.boost,
             **self.kwargs,

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -96,7 +96,7 @@ def test_qparser_entry_points_are_annotated():
     from whoosh.qparser import default as qpdefault
 
     # QueryParser core methods.
-    for name in ("__init__", "parse", "parse_", "process", "tag"):
+    for name in ("__init__", "parse", "process", "tag"):
         method = getattr(qpdefault.QueryParser, name)
         sig = inspect.signature(method)
         for pname, param in sig.parameters.items():


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

This PR tackles two single-instance typing rules to help clear `pyproject.toml`:
1. **`empty-body`**: Removed the dead `parse_` stub in `src/whoosh/qparser/default.py`. A quick `git grep` confirmed it had no callers.
2. **`parameter-already-assigned`**: Fixed a double assignment of the `boost` parameter in `GroupNode.apply` (`src/whoosh/qparser/syntax.py`) by removing the residual positional `self.type` argument.

Both rules have been successfully un-ignored in `pyproject.toml`.

## Related issues

References #121

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [x] Added/updated tests for the change where it makes sense
- [ ] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](https://github.com/priya-sundaram-dev/whoosh/blob/main/CONTRIBUTING.md) guide
