### PR TITLE
Remove the dead byte-oriented base85 codec

### DIFF
--- a/src/whoosh/support/base85.py
+++ b/src/whoosh/support/base85.py
@@ -1,13 +1,15 @@
 """
-This module contains generic base85 encoding and decoding functions. The
-whoosh.util.numeric module contains faster variants for encoding and
-decoding integers.
+This module contains base85 encoding and decoding functions for integers.
+The whoosh.util.numeric module contains faster variants.
+
+Unlike the standard ascii85/base85 alphabets, the character set here is in
+ASCII order, so encoded strings sort in the same order as the integers they
+encode. whoosh.codec.whoosh2 relies on that property, so the alphabet cannot
+be swapped for the one in the stdlib base64 module.
 
 Modified from:
 http://paste.lisp.org/display/72815
 """
-
-import struct
 
 # Instead of using the character set from the ascii85 algorithm, I put the
 # characters in order so that the encoded text sorts properly (my life would be
@@ -42,62 +44,3 @@ def from_base85(text):
     for c in text:
         acc = acc * 85 + b85dec[c]
     return acc
-
-
-# Bytes encoding and decoding functions
-
-
-def b85encode(text, pad=False):
-    length = len(text)
-    if r := length % 4:
-        text += "\0" * (4 - r)
-    longs = len(text) >> 2
-    out = []
-    words = struct.unpack(">" + "L" * longs, text[0 : longs * 4])
-    for word in words:
-        rems = [0, 0, 0, 0, 0]
-        for i in range(4, -1, -1):
-            rems[i] = b85chars[word % 85]
-            word /= 85
-        out.extend(rems)
-
-    out = "".join(out)
-    if pad:
-        return out
-
-    # Trim padding
-    olen = length % 4
-    if olen:
-        olen += 1
-    olen += length // 4 * 5
-    return out[0:olen]
-
-
-def b85decode(text):
-    length = len(text)
-    out = []
-    for i in range(0, len(text), 5):
-        chunk = text[i : i + 5]
-        acc = 0
-        for j in range(len(chunk)):
-            try:
-                acc = acc * 85 + b85dec[chunk[j]]
-            except KeyError:
-                raise TypeError("Bad base85 character at byte %d" % (i + j))
-        if acc > 4294967295:
-            raise OverflowError("Base85 overflow in hunk starting at byte %d" % i)
-        out.append(acc)
-
-    # Pad final chunk if necessary
-    cl = length % 5
-    if cl:
-        acc *= 85 ** (5 - cl)
-        if cl > 1:
-            acc += 0xFFFFFF >> (cl - 2) * 8
-        out[-1] = acc
-
-    out = struct.pack(">" + "L" * ((length + 4) / 5), *out)
-    if cl:
-        out = out[: -(5 - cl)]
-
-    return out

--- a/tests/test_base85.py
+++ b/tests/test_base85.py
@@ -1,0 +1,53 @@
+import random
+
+from whoosh.codec.whoosh2 import sortable_int_to_text
+from whoosh.support.base85 import b85chars, from_base85, to_base85
+
+# 85 ** 5 and 85 ** 10 -- one past the largest value each width can hold.
+INT_LIMIT = 85**5
+LONG_LIMIT = 85**10
+
+
+def test_roundtrip_int():
+    for x in (0, 1, 84, 85, 86, 7225, 123456, INT_LIMIT - 1):
+        assert from_base85(to_base85(x)) == x
+
+
+def test_roundtrip_long():
+    for x in (0, 1, INT_LIMIT, INT_LIMIT + 1, LONG_LIMIT - 1):
+        assert from_base85(to_base85(x, True)) == x
+
+
+def test_fixed_width():
+    # Fixed width is what makes the encoding sortable: a shorter string must
+    # never compare less than a longer one just for being shorter.
+    assert all(len(to_base85(x)) == 5 for x in (0, 1, INT_LIMIT - 1))
+    assert all(len(to_base85(x, True)) == 10 for x in (0, 1, LONG_LIMIT - 1))
+
+
+def test_alphabet_is_in_ascii_order():
+    # The whole point of the custom alphabet -- the stdlib base64.b85 alphabet
+    # is not ordered, so it cannot be substituted here.
+    assert list(b85chars) == sorted(b85chars)
+    assert len(set(b85chars)) == 85
+
+
+def test_encoding_preserves_order():
+    numbers = sorted(random.sample(range(INT_LIMIT), 200))
+    encoded = [to_base85(x) for x in numbers]
+    assert encoded == sorted(encoded)
+
+
+def test_encoding_preserves_order_long():
+    # randrange rather than sample: range(85 ** 10) is too large for
+    # random.sample to take a len() of.
+    numbers = sorted(random.randrange(LONG_LIMIT) for _ in range(200))
+    encoded = [to_base85(x, True) for x in numbers]
+    assert encoded == sorted(encoded)
+
+
+def test_sortable_int_to_text_preserves_order():
+    # The property whoosh2 actually depends on, exercised through its own API.
+    numbers = sorted(random.sample(range(INT_LIMIT), 100))
+    encoded = [sortable_int_to_text(x) for x in numbers]
+    assert encoded == sorted(encoded)


### PR DESCRIPTION
Closes #139.

Took the delete option rather than the stdlib-wrapper option, for a reason worth stating explicitly.

### Why not wrap `base64.b85encode`

The two alphabets are not interchangeable:

```python
>>> from whoosh.support.base85 import b85chars
>>> list(b85chars) == sorted(b85chars)          # this module
True
>>> # stdlib base64.b85 alphabet: 0-9A-Za-z!#$%&()*+-;<=>?@^_`{|}~
>>> list(std) == sorted(std)
False
```

That ordering is the entire reason the custom alphabet exists — the comment in the file says as much — and `whoosh2.py:2250` uses it under a heading that reads *"Functions for converting sortable representations to and from text"*:

```python
def sortable_int_to_text(x, shift=0):
    text = chr(shift) + to_base85(x, False)
```

So a stdlib-backed `b85encode` would be a different codec wearing the same name, in a module whose one distinguishing feature is sortability. Deleting is the honest option; if a working byte codec is ever wanted, callers can reach for `base64` directly and be explicit about which alphabet they mean.

### Confirming it really is dead

Neither function is referenced anywhere outside its own definition:

```
$ grep -rn "b85encode\|b85decode" --include=*.py . | grep -v support/base85.py
(no output)
```

And both raise on every input type, so no caller could have been relying on them even accidentally:

```
b85encode(b"hello") -> TypeError: can't concat str to bytes
b85encode("hello")  -> TypeError: a bytes-like object is required, not 'str'
b85decode("abcde")  -> TypeError: can't multiply sequence by non-int of type 'float'
```

`b85encode` is broken on both branches, not just the `word /= 85` one #139 mentions — it also does `text += "\0" * (4 - r)` on what `struct.unpack` then requires to be bytes.

### What is kept

`b85chars`, `b85dec`, `to_base85`, `from_base85`. `import struct` is dropped (only the byte codec used it). The module docstring said "generic base85 encoding and decoding functions", which is no longer accurate, so it now says what the module provides and why the alphabet cannot be swapped — to save the next person from re-proposing the stdlib wrapper.

### Tests

New `tests/test_base85.py`, 7 cases: both roundtrips, fixed width (5 and 10 chars — the thing that makes it sortable), the alphabet being in ASCII order and 85 characters, and the order-preserving property both directly and through `sortable_int_to_text`.

There was no coverage of this module at all before, which is why CI stayed green over broken code.

- `pytest tests/` — 869 passed, 8 skipped (platform/optional-dep skips, unchanged)
- `ruff check` — clean; `ruff format --check` — already formatted