### PR TITLE
Document why base85's alphabet is ordered, and test the invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Added
+- Property-based tests for `whoosh.support.base85` covering the invariants the
+  module exists for: the alphabet being in ASCII order, fixed-width output, and
+  encoded values sorting in the same order as the integers they encode -- the
+  last asserted both directly and through `whoosh2`'s `sortable_int_to_text`
+  and `sortable_long_to_text` (#139). Thanks @chmm195.
+
+### Changed
+- `whoosh.support.base85`'s module docstring now explains why the alphabet is
+  in ASCII order and why it must not be replaced with `base64.b85encode`, whose
+  alphabet is unordered (#139). Thanks @chmm195.
+
 ## [3.47.0] - 2026-08-25
 
 ### Fixed

--- a/src/whoosh/support/base85.py
+++ b/src/whoosh/support/base85.py
@@ -1,7 +1,18 @@
 """
-This module contains generic base85 encoding and decoding functions. The
-whoosh.util.numeric module contains faster variants for encoding and
-decoding integers.
+This module contains base85 encoding and decoding functions for integers.
+The whoosh.util.numeric module contains faster variants.
+
+Unlike the standard ascii85/base85 alphabets, the character set here is in
+ASCII order, so encoded strings sort in the same order as the integers they
+encode. whoosh.codec.whoosh2's sortable_int_to_text/sortable_long_to_text
+rely on that property, so the alphabet must not be swapped for the one in
+the stdlib base64 module -- base64.b85encode's alphabet is not ordered, and
+substituting it would silently break sorted-order lookups on existing
+indexes.
+
+Encoded values are also fixed width (5 characters, or 10 with islong=True),
+which is the other half of what makes them sortable: a shorter string must
+never compare less than a longer one just for being shorter.
 
 Modified from:
 http://paste.lisp.org/display/72815

--- a/tests/test_base85.py
+++ b/tests/test_base85.py
@@ -1,12 +1,28 @@
+"""Tests for whoosh.support.base85.
+
+The module exists to encode integers so that the encoded strings sort in the
+same order as the integers -- that is the property whoosh2's sortable_*_to_text
+depends on, and it is the thing a well-meaning refactor to base64.b85encode
+would silently break. A roundtrip test alone would not catch that, so the
+ordering and fixed-width invariants are asserted directly.
+"""
+
+import random
+
+from whoosh.codec.whoosh2 import sortable_int_to_text, sortable_long_to_text
 from whoosh.support import base85
-from whoosh.support.base85 import from_base85, to_base85
+from whoosh.support.base85 import b85chars, from_base85, to_base85
+
+# One past the largest value each width can hold.
+INT_LIMIT = 85**5
+LONG_LIMIT = 85**10
 
 
 def test_integer_roundtrip():
-    for x in [0, 1, 84, 85, 1000, 2**31, 85**5 - 1]:
+    for x in [0, 1, 84, 85, 86, 1000, 2**31, INT_LIMIT - 1]:
         assert from_base85(to_base85(x)) == x
 
-    for x in [0, 1, 2**31, 2**48, 85**10 - 1]:
+    for x in [0, 1, 2**31, 2**48, INT_LIMIT, LONG_LIMIT - 1]:
         assert from_base85(to_base85(x, islong=True)) == x
 
 
@@ -15,3 +31,54 @@ def test_byte_codec_removed():
     # make sure it is not reintroduced without a working implementation.
     assert not hasattr(base85, "b85encode")
     assert not hasattr(base85, "b85decode")
+
+
+def test_alphabet_is_in_ascii_order():
+    # The reason for the custom alphabet. base64.b85encode's alphabet is not
+    # ordered, so it cannot be substituted here without breaking sort order.
+    assert list(b85chars) == sorted(b85chars)
+    assert len(b85chars) == 85
+    assert len(set(b85chars)) == 85
+
+
+def test_encoding_is_fixed_width():
+    # The other half of sortability: a shorter string must never compare less
+    # than a longer one just for being shorter.
+    assert all(len(to_base85(x)) == 5 for x in (0, 1, 84, INT_LIMIT - 1))
+    assert all(len(to_base85(x, islong=True)) == 10 for x in (0, 1, LONG_LIMIT - 1))
+
+
+def test_encoding_preserves_order():
+    numbers = sorted(random.sample(range(INT_LIMIT), 200))
+    encoded = [to_base85(x) for x in numbers]
+    assert encoded == sorted(encoded)
+
+
+def test_encoding_preserves_order_long():
+    # randrange rather than sample: range(85 ** 10) is too large for
+    # random.sample to take a len() of.
+    numbers = sorted(random.randrange(LONG_LIMIT) for _ in range(200))
+    encoded = [to_base85(x, islong=True) for x in numbers]
+    assert encoded == sorted(encoded)
+
+
+def test_adjacent_values_stay_adjacent_in_order():
+    # Catches an off-by-one in the carry that random sampling could miss.
+    encoded = [to_base85(x) for x in range(84, 87)]
+    assert encoded == sorted(encoded)
+
+
+def test_sortable_int_to_text_preserves_order():
+    # The invariant exercised through whoosh2's own API, which is what
+    # actually depends on it.
+    numbers = sorted(random.sample(range(INT_LIMIT), 100))
+    assert [sortable_int_to_text(x) for x in numbers] == sorted(
+        sortable_int_to_text(x) for x in numbers
+    )
+
+
+def test_sortable_long_to_text_preserves_order():
+    numbers = sorted(random.randrange(LONG_LIMIT) for _ in range(100))
+    assert [sortable_long_to_text(x) for x in numbers] == sorted(
+        sortable_long_to_text(x) for x in numbers
+    )


### PR DESCRIPTION
Follow-up to #142 as you suggested, rebased on current `main` with #141 already in. Thanks for the generous writeup — @SAY-5 got there first and fair is fair.

Two pieces, exactly the two you asked for.

### 1. The docstring

It still said "generic base85 encoding and decoding functions", which stopped being true once the byte codec went, and gave no hint that the alphabet is deliberately ordered. The explanation now sits directly above the code someone would edit:

> Unlike the standard ascii85/base85 alphabets, the character set here is in ASCII order, so encoded strings sort in the same order as the integers they encode. `whoosh.codec.whoosh2`'s `sortable_int_to_text`/`sortable_long_to_text` rely on that property, so the alphabet must not be swapped for the one in the stdlib `base64` module […] substituting it would silently break sorted-order lookups on existing indexes.

I added the fixed-width half too, since it is the other reason the encoding sorts: without it a shorter string could compare less than a longer one just for being shorter.

### 2. The tests

Kept your `test_integer_roundtrip` (widened slightly) and **kept `test_byte_codec_removed` from #141** rather than replacing the file wholesale — you said "replaces", but a guard against the dead codec being reintroduced is worth more than the four lines it costs, and it is testing something none of my cases do. Say the word if you would rather it go.

Added on top:

| Test | Invariant |
| --- | --- |
| `test_alphabet_is_in_ascii_order` | ordered, 85 unique chars — the reason `base64.b85` cannot be substituted |
| `test_encoding_is_fixed_width` | 5 / 10 chars regardless of magnitude |
| `test_encoding_preserves_order` / `_long` | encoded order matches integer order |
| `test_adjacent_values_stay_adjacent_in_order` | 84/85/86 across the carry, which random sampling can miss |
| `test_sortable_int_to_text_preserves_order` / `_long` | the same property through `whoosh2`'s API, which is what actually depends on it |

The long-width order test uses `random.randrange` rather than `random.sample`: `range(85 ** 10)` overflows `ssize_t` when `sample` takes its `len()`.

### CHANGELOG

Added an `[Unreleased]` entry under Added/Changed in your existing style. I put my own attribution in it because you offered — please just edit or drop it if you would rather word that yourself.

### Verification

- `pytest tests/` — **871 passed**, 8 skipped (platform/optional-dep skips, unchanged from `main`)
- `pytest tests/test_base85.py` — 9 passed
- `ruff check` / `ruff format --check` — clean on both changed files