### PR TITLE
Fix TimeLimitCollector crash in worker threads (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Fixed
+- `TimeLimitCollector` no longer crashes with `ValueError: signal only works
+  in the main thread of the main interpreter` when a search is run from a
+  worker thread (e.g. a threaded web server). The `SIGALRM` handler is now
+  only armed on the main thread; off the main thread the collector falls back
+  to its `threading.Timer`, which still enforces the time limit. Surfaced while
+  auditing thread-safety under `pytest-run-parallel` (#146).
+
 ### Added
 - Property-based tests for `whoosh.support.base85` covering the invariants the
   module exists for: the alphabet being in ASCII order, fixed-width output, and

--- a/src/whoosh/collectors.py
+++ b/src/whoosh/collectors.py
@@ -1081,7 +1081,16 @@ class TimeLimitCollector(WrappingCollector):
         if use_alarm:
             import signal
 
-            self.use_alarm = use_alarm and hasattr(signal, "SIGALRM")
+            # signal.signal() only works in the main thread of the main
+            # interpreter, so only arm the SIGALRM handler when we are there.
+            # In worker threads (e.g. a threaded web server) we fall back to
+            # the threading.Timer below, which is enough to flip ``timedout``
+            # and stop the collect loop.
+            self.use_alarm = (
+                use_alarm
+                and hasattr(signal, "SIGALRM")
+                and threading.current_thread() is threading.main_thread()
+            )
         else:
             self.use_alarm = False
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -173,6 +173,58 @@ def test_timelimit_alarm():
         assert time.time() - t < 0.5, f"Actual time interval: {time.time() - t}"
 
 
+def test_timelimit_worker_thread():
+    # A TimeLimitCollector must not crash when created and run outside the
+    # main thread: signal.signal() only works in the main thread, so the
+    # collector should silently fall back to its threading.Timer and still
+    # enforce the time limit. Regression test for issue #146.
+    import threading
+    import time
+
+    from whoosh import collectors, matching
+
+    schema = fields.Schema(text=fields.TEXT)
+    ix = RamStorage().create_index(schema)
+    w = ix.writer()
+    for _ in range(50):
+        w.add_document(text="alfa")
+    w.commit()
+
+    class SlowMatcher(matching.WrappingMatcher):
+        def next(self):
+            time.sleep(0.02)
+            self.child.next()
+
+    class SlowQuery(query.WrappingQuery):
+        def matcher(self, searcher, context=None):
+            return SlowMatcher(self.child.matcher(searcher, context))
+
+    result = {}
+
+    def run():
+        try:
+            with ix.searcher() as s:
+                sq = SlowQuery(query.Term("text", "alfa"))
+                col = collectors.TimeLimitCollector(
+                    s.collector(limit=None), timelimit=0.1
+                )
+                # use_alarm should have been auto-disabled off the main thread
+                assert col.use_alarm is False
+                try:
+                    s.search_with_collector(sq, col)
+                    result["timed_out"] = False
+                except searching.TimeLimit:
+                    result["timed_out"] = True
+        except Exception as e:  # noqa: BLE001
+            result["error"] = e
+
+    t = threading.Thread(target=run)
+    t.start()
+    t.join(timeout=10)
+    assert "error" not in result, result.get("error")
+    assert result.get("timed_out") is True
+
+
 def test_reverse_collapse():
     from whoosh import sorting
 


### PR DESCRIPTION
While auditing thread-safety under `pytest-run-parallel` for #146, I found a real bug worth fixing on its own: `TimeLimitCollector` crashes with `ValueError: signal only works in the main thread of the main interpreter` when a search runs from a worker thread — a common case in threaded web servers.

**Fix:** only arm the `SIGALRM` handler on the main thread. Off the main thread the collector falls back to its existing `threading.Timer`, which already flips `timedout` and stops the collect loop, so the time limit is still enforced. Adds a regression test that runs a `TimeLimitCollector` from a worker thread and asserts it times out cleanly.

This clears 2 of the errors seen in the `test_collector.py` parallel run in #146. I'll follow up on #146 with the rest of the investigation (the remaining failures are test-harness artifacts, not core races).

Closes part of #146.
