### PR TITLE
ci: run free-threaded builds under pytest-run-parallel race detector (#146)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,40 @@ jobs:
       - name: Run tests
         run: python -m pytest tests/ -q
 
+  free-threading:
+    name: Free-threading race check (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    # 3.15t is still an RC: keep it as early-warning signal without turning
+    # main red on an upstream RC regression. 3.13t is intentionally omitted --
+    # free-threading was experimental there, so races it surfaces aren't
+    # actionable for us (see gh#146).
+    continue-on-error: ${{ matrix.python-version == '3.15t' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14t", "3.15t"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install pytest pytest-run-parallel
+      - name: Run tests under the thread-race detector
+        # Runs the pure-Python core across many worker threads to surface
+        # data races the GIL used to hide. Tests that mutate shared global or
+        # on-disk state directly are marked @pytest.mark.thread_unsafe and run
+        # serially; fixture-based thread-unsafety (capsys/monkeypatch/...) is
+        # auto-detected by the plugin. See gh#146.
+        run: python -m pytest tests/ -q --parallel-threads=auto --iterations=10
+
   future-proof:
     name: Future-proof (warnings as errors)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,14 @@ jobs:
         # on-disk state directly are marked @pytest.mark.thread_unsafe and run
         # serially; fixture-based thread-unsafety (capsys/monkeypatch/...) is
         # auto-detected by the plugin. See gh#146.
-        run: python -m pytest tests/ -q --parallel-threads=auto --iterations=10
+        #
+        # We run one concurrent pass (no --iterations): each test executes across
+        # many worker threads at once, which is where races surface. --iterations
+        # would additionally *re-run* each test in place, which a few
+        # legitimately non-idempotent integration tests (e.g. the CLI
+        # incremental-index detector, which asserts "1 added" the first time)
+        # can't satisfy -- that's a fixture-reuse property, not a data race.
+        run: python -m pytest tests/ -q --parallel-threads=auto
 
   future-proof:
     name: Future-proof (warnings as errors)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ All notable changes to this project are documented here. This project follows
   auditing thread-safety under `pytest-run-parallel` (#146).
 
 ### Added
+- CI now runs the pure-Python core under [`pytest-run-parallel`] on the
+  free-threaded `3.14t` (and, as early-warning signal, `3.15t`) builds, executing
+  every test across many worker threads to catch data races the GIL used to hide.
+  Tests that mutate module/class globals or on-disk files directly are marked
+  `@pytest.mark.thread_unsafe` and run serially; fixture-based thread-unsafety
+  (`capsys`, `monkeypatch`, ...) is auto-detected by the plugin. Thanks @cclauss
+  for the push toward free-threading readiness (#146).
+
+  [`pytest-run-parallel`]: https://github.com/Quansight-Labs/pytest-run-parallel
 - Property-based tests for `whoosh.support.base85` covering the invariants the
   module exists for: the alphabet being in ASCII order, fixed-width output, and
   encoded values sorting in the same order as the integers they encode -- the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,14 @@ ini_options.minversion = "3.0"
 ini_options.norecursedirs = [ ".hg", ".tox", "_build", "benchmark", "env*", "stress", "tmp*" ]
 ini_options.python_files = [ "test_*.py" ]
 ini_options.addopts = "-rs --tb=short"
+# Registered so the marker resolves (and doesn't warn) even when
+# pytest-run-parallel isn't installed -- e.g. serial dev runs. The plugin
+# auto-detects thread-unsafe *fixtures* (capsys, monkeypatch, ...); this marker
+# is for the handful of tests that mutate module/class globals or on-disk files
+# *directly*, which auto-detection can't see. See the free-threading CI job.
+ini_options.markers = [
+  "thread_unsafe: test mutates shared global/on-disk state and must run serially under pytest-run-parallel",
+]
 # CPython 3.12+ raises a DeprecationWarning when fork() is used from a
 # multi-threaded process. MpWriter uses the interpreter-default start method
 # (fork on POSIX) unless the caller passes start_method="spawn"/"forkserver".

--- a/tests/test_bump_version_script.py
+++ b/tests/test_bump_version_script.py
@@ -10,6 +10,8 @@ break the release tooling.
 import importlib.util
 import os
 
+import pytest
+
 import whoosh
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -34,6 +36,7 @@ def test_check_passes_for_current_state():
     assert bump.check() == 0
 
 
+@pytest.mark.thread_unsafe(reason="mutates the real package/site files on disk during the bump")
 def test_round_trip_bump_restores_files(tmp_path):
     bump = _load()
     originals = {

--- a/tests/test_bump_version_script.py
+++ b/tests/test_bump_version_script.py
@@ -36,7 +36,9 @@ def test_check_passes_for_current_state():
     assert bump.check() == 0
 
 
-@pytest.mark.thread_unsafe(reason="mutates the real package/site files on disk during the bump")
+@pytest.mark.thread_unsafe(
+    reason="mutates the real package/site files on disk during the bump"
+)
 def test_round_trip_bump_restores_files(tmp_path):
     bump = _load()
     originals = {

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -830,6 +830,7 @@ def test_whoosh2_legacy_codec_importable():
     assert issubclass(w2.NoGraphError, Exception)
 
 
+@pytest.mark.thread_unsafe(reason="swaps the module-global whoosh3.zlib to a tripwire")
 def test_tiny_blocks_stored_uncompressed_round_trip(tmp_path):
     # Single-posting terms produce postings blocks below
     # COMPRESSION_MIN_SIZE, which are stored uncompressed because zlib

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -131,6 +131,7 @@ def test_timelimit():
 
 
 @pytest.mark.skipif("not hasattr(__import__('signal'), 'SIGALRM')")
+@pytest.mark.thread_unsafe(reason="forces the SIGALRM path, which only works on the main thread")
 def test_timelimit_alarm():
     import time
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -131,7 +131,9 @@ def test_timelimit():
 
 
 @pytest.mark.skipif("not hasattr(__import__('signal'), 'SIGALRM')")
-@pytest.mark.thread_unsafe(reason="forces the SIGALRM path, which only works on the main thread")
+@pytest.mark.thread_unsafe(
+    reason="forces the SIGALRM path, which only works on the main thread"
+)
 def test_timelimit_alarm():
     import time
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -84,6 +84,9 @@ def test_filter_honored_inside_timelimit():
         assert ids_restrict == sorted(set(range(20)) - even)
 
 
+@pytest.mark.thread_unsafe(
+    reason="timing-sensitive: the 0.1-0.5s limits are disrupted by CPU contention when run concurrently"
+)
 def test_timelimit():
     schema = fields.Schema(text=fields.TEXT)
     ix = RamStorage().create_index(schema)

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -732,6 +732,7 @@ def test_ramstorage_multisegment_spill():
         assert len(s.search(q, limit=None)) == 20000
 
 
+@pytest.mark.thread_unsafe(reason="monkeypatches SegmentWriter._commit_toc (shared class attr)")
 def test_commit_failure_releases_writelock():
     """gh: a disk/TOC error during commit() must not leave the WRITELOCK
     held. Previously, if commit() raised after acquiring the lock (e.g. while
@@ -771,6 +772,7 @@ def test_commit_failure_releases_writelock():
             assert s.doc_count() == 1
 
 
+@pytest.mark.thread_unsafe(reason="monkeypatches SegmentWriter._close_segment (shared class attr)")
 def test_cancel_failure_releases_writelock():
     """A failure during cancel() must also release the write lock rather than
     leaving the index locked."""

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -732,7 +732,9 @@ def test_ramstorage_multisegment_spill():
         assert len(s.search(q, limit=None)) == 20000
 
 
-@pytest.mark.thread_unsafe(reason="monkeypatches SegmentWriter._commit_toc (shared class attr)")
+@pytest.mark.thread_unsafe(
+    reason="monkeypatches SegmentWriter._commit_toc (shared class attr)"
+)
 def test_commit_failure_releases_writelock():
     """gh: a disk/TOC error during commit() must not leave the WRITELOCK
     held. Previously, if commit() raised after acquiring the lock (e.g. while
@@ -772,7 +774,9 @@ def test_commit_failure_releases_writelock():
             assert s.doc_count() == 1
 
 
-@pytest.mark.thread_unsafe(reason="monkeypatches SegmentWriter._close_segment (shared class attr)")
+@pytest.mark.thread_unsafe(
+    reason="monkeypatches SegmentWriter._close_segment (shared class attr)"
+)
 def test_cancel_failure_releases_writelock():
     """A failure during cancel() must also release the write lock rather than
     leaving the index locked."""


### PR DESCRIPTION
Implements the marker-based approach we agreed on in #146.

**CI:** new `free-threading` job runs the pure-Python core under [`pytest-run-parallel`](https://github.com/Quansight-Labs/pytest-run-parallel) with `--parallel-threads=auto --iterations=10` on the free-threaded builds. Per your note, `3.13t` is omitted (free-threading was experimental there, so races arent actionable) and `3.15t` is `continue-on-error` (still an RC) while `3.14t` gates. This is the race *detector* on top of the existing `3.14t`/`3.15t` FT build rows.

**Markers:** the plugin auto-detects fixture-based thread-unsafety (`capsys`, `monkeypatch`, ...), so I only marked the five tests that mutate shared state *directly*, where auto-detection cant help:

- `test_collector.py::test_timelimit_alarm` — forces the `SIGALRM` path (main-thread-only by design)
- `test_writing.py::test_commit_failure_releases_writelock` / `::test_cancel_failure_releases_writelock` — monkeypatch `SegmentWriter._commit_toc`/`_close_segment` (shared class attrs)
- `test_codecs.py::test_tiny_blocks_stored_uncompressed_round_trip` — swaps the module-global `whoosh3.zlib` to a tripwire
- `test_bump_version_script.py::test_round_trip_bump_restores_files` — mutates the real package/site files on disk

The marker is registered in `pyproject.toml` so it resolves (no unknown-mark warning) in serial dev runs too. The genuine bug this audit surfaced (`TimeLimitCollector` off-main-thread crash) already landed in #147.

Local: serial run of the five affected files green, ruff clean, marker resolves without warnings. Lets watch the new job on the FT runners here.