### PR TITLE
ci: install CI/docs/publish deps with uv (keep setup-python provisioning)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Install
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e "${{ matrix.extras }}"
-          python -m pip install pytest
+          uv pip install --system -e "${{ matrix.extras }}"
+          uv pip install --system pytest
       - name: Run tests
         run: python -m pytest tests/ -q
 
@@ -84,11 +84,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Install
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .
-          python -m pip install pytest pytest-run-parallel
+          uv pip install --system -e .
+          uv pip install --system pytest pytest-run-parallel
       - name: Run tests under the thread-race detector
         # Runs the pure-Python core across many worker threads to surface
         # data races the GIL used to hide. Tests that mutate shared global or
@@ -115,11 +115,11 @@ jobs:
         with:
           python-version: "3.x"
           allow-prereleases: true
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Install
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[langchain,llamaindex]"
-          python -m pip install pytest
+          uv pip install --system -e ".[langchain,llamaindex]"
+          uv pip install --system pytest
       - name: Run tests with DeprecationWarning promoted to error
         # Guards the "runs clean on modern Python" promise: if a future
         # CPython deprecates something Whoosh relies on, this job fails
@@ -156,11 +156,11 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Install
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .
-          python -m pip install mypy
+          uv pip install --system -e .
+          uv pip install --system mypy
       - name: mypy type-check the public-API smoke fixture
         # Type-checks tests/typing_smoke.py (a realistic downstream-usage
         # snippet) against Whoosh's shipped annotations. Guards that the

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,11 +37,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
       - name: Install docs dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .
-          pip install -r docs/requirements.txt
+          uv pip install --system -e .
+          uv pip install --system -r docs/requirements.txt
 
       - name: Build Sphinx docs
         run: |
@@ -49,7 +50,7 @@ jobs:
 
       - name: Build current wheel for the browser demo
         run: |
-          python -m pip install build
+          uv pip install --system build
           python -m build --wheel
           # Keep the real wheel filename: micropip validates it against PEP 440,
           # so a "latest" pseudo-version is rejected as an invalid wheel name.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          # This is a release-publishing workflow; disable uv's cache so a
+          # poisoned cache entry can't influence the artifacts we build and
+          # upload to PyPI (flagged by zizmor's cache-poisoning audit).
+          enable-cache: false
       - name: Build sdist and wheel
         run: |
           uv pip install --system build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,13 +22,14 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Build sdist and wheel
         run: |
-          python -m pip install --upgrade pip build
+          uv pip install --system build
           python -m build
       - name: Check metadata
         run: |
-          python -m pip install twine
+          uv pip install --system twine
           python -m twine check dist/*
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ All notable changes to this project are documented here. This project follows
   and `sortable_long_to_text` (#139). Thanks @chmm195.
 
 ### Changed
+- CI now installs dependencies with [`uv`](https://docs.astral.sh/uv/) (via
+  `astral-sh/setup-uv`) across the test, docs, and publish workflows for faster,
+  more reproducible installs. `actions/setup-python` still provisions the
+  interpreters so the prerelease (3.15 RC) and free-threaded (`3.14t`/`3.15t`)
+  matrix rows are preserved. Thanks @cclauss (#149).
+- README now shows a `uv pip install whoosh3` quickstart alongside `pip` (#149).
 - `whoosh.support.base85`'s module docstring now explains why the alphabet is
   in ASCII order and why it must not be replaced with `base64.b85encode`, whose
   alphabet is unordered (#139). Thanks @chmm195.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ shines when you want good search *inside* a Python process without extra infra.
 pip install whoosh3
 ```
 
+Or with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv pip install whoosh3
+```
+
 ```python
 import whoosh
 print(whoosh.versionstring())


### PR DESCRIPTION
Implements the two pieces of #149 we agreed on, keeping the parts that fit a library.

## What changed
- **`uv` for installs in CI.** Swapped `python -m pip install …` → `uv pip install --system …` in the test, docs (`pages.yml`), and publish (`publish.yml`) workflows. `astral-sh/setup-uv` (pinned by SHA, already used by the lint/pre-commit jobs) is added to each job that installs.
- **`actions/setup-python` kept for provisioning.** It still installs the interpreters with `allow-prereleases: true`, so the 3.15 RC row and the free-threaded `3.14t`/`3.15t` rows — which have caught real threading races (#146, #148) — are preserved. Only the *install step* moved to `uv`.
- **README** gains a `uv pip install whoosh3` quickstart next to `pip`.

## What we deliberately left out
Per the discussion in #149, no committed `uv.lock` / `uv-pre-commit`. Whoosh is a library and should keep floating within its declared version ranges rather than pinning one resolution; a lockfile users never see would add churn without protecting them.

Thanks @cclauss for the push toward modern tooling. Closes #149.