### PR TITLE
Fix Whoosh 2.7.4 → whoosh3 migration regressions (SpanNot IndexError, span __str__, Hit.get) (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to this project are documented here. This project follows
 ## [Unreleased]
 
 ### Fixed
+- Whoosh 2.7.4 → whoosh3 migration regressions in span queries and hits,
+  reported by @BenitoKme (#153):
+  - Searching with `SpanNot` raised `IndexError: tuple index out of range`
+    whenever the excluded (second) span did not match in a candidate
+    document. `SpanNot._get_spans()` called `id()` on the exhausted "maybe"
+    matcher; it now checks `is_active()` first (nothing to exclude → all
+    spans from the first query pass through).
+  - `str()` on any span query (`SpanNot`, `SpanNear`, `SpanOr`, ...) raised
+    `NotImplementedError` from the base `Query.__str__`. Span queries have no
+    dedicated query-language syntax, so `SpanQuery.__str__` now falls back to
+    the well-defined `repr`.
+  - `Hit.get(key[, default])` was missing, breaking dict-style
+    `hit.get("field", fallback)` access that worked in Whoosh 2.7.4. The
+    standard `dict.get` accessor is restored.
 - `whoosh.support.bitstream.BitStreamReader.read` raised a tuple
   (`raise (IndexError, ...)`) instead of an exception on an out-of-range
   read, so callers got an unrelated `TypeError` rather than the intended

--- a/src/whoosh/query/spans.py
+++ b/src/whoosh/query/spans.py
@@ -304,6 +304,12 @@ class SpanQuery(Query):
     def __repr__(self):
         return f"{self.__class__.__name__}({self.q!r})"
 
+    def __str__(self):
+        # Span queries have no dedicated query-language syntax, so fall back to
+        # the (recursive, well-defined) repr instead of raising
+        # NotImplementedError from the base Query.__str__ (gh#153).
+        return repr(self)
+
     def __eq__(self, other):
         return other and self.__class__ is other.__class__ and self.q == other.q
 
@@ -828,7 +834,12 @@ class SpanNot(SpanBiQuery):
             super().__init__(amm)
 
         def _get_spans(self):
-            if self.a.id() == self.b.id():
+            # ``b`` is the excluded ("maybe") side of the underlying
+            # AndMaybeMatcher, so it can be exhausted / positioned on a
+            # different document than ``a``. Guard against calling ``id()`` on
+            # an inactive matcher, which raised ``IndexError`` (gh#153). When
+            # ``b`` has nothing for this document there is nothing to exclude.
+            if self.b.is_active() and self.a.id() == self.b.id():
                 spans = []
                 bspans = self.b.spans()
                 for aspan in self.a.spans():

--- a/src/whoosh/searching.py
+++ b/src/whoosh/searching.py
@@ -1647,6 +1647,17 @@ class Hit:
     def __contains__(self, key):
         return key in self.fields() or self.reader.has_column(key)
 
+    def get(self, key, default=None):
+        """Returns the value of the stored field ``key`` for this hit, or
+        ``default`` (``None`` if not given) if the field is not present. This
+        mirrors the standard ``dict.get`` interface.
+        """
+
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
     def items(self) -> list[tuple[str, Any]]:
         return list(self.fields().items())
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -701,9 +701,11 @@ def test_filter_by_result():
 def test_hit_get_dict_interface():
     # gh#153: Hit should support the standard dict-like .get() accessor
     # (Whoosh 2.7.4 compatibility). Missing before whoosh3.
-    schema = fields.Schema(id=fields.ID(stored=True),
-                           source_path=fields.ID(stored=True),
-                           content=fields.TEXT(stored=True))
+    schema = fields.Schema(
+        id=fields.ID(stored=True),
+        source_path=fields.ID(stored=True),
+        content=fields.TEXT(stored=True),
+    )
     with TempIndex(schema, "hitget") as ix:
         with ix.writer() as w:
             w.add_document(id="1", source_path="a/b.txt", content="alfa bravo")

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -696,3 +696,21 @@ def test_filter_by_result():
             # filter_result.docs()
             result = searcher.search(q, filter=filter_result)
             assert all(x["title"] == "even" and x["content"] == "foo" for x in result)
+
+
+def test_hit_get_dict_interface():
+    # gh#153: Hit should support the standard dict-like .get() accessor
+    # (Whoosh 2.7.4 compatibility). Missing before whoosh3.
+    schema = fields.Schema(id=fields.ID(stored=True),
+                           source_path=fields.ID(stored=True),
+                           content=fields.TEXT(stored=True))
+    with TempIndex(schema, "hitget") as ix:
+        with ix.writer() as w:
+            w.add_document(id="1", source_path="a/b.txt", content="alfa bravo")
+        with ix.searcher() as s:
+            r = s.search(query.Term("content", "alfa"))
+            hit = r[0]
+            assert hit.get("source_path") == "a/b.txt"
+            assert hit.get("source_path", "???") == "a/b.txt"
+            assert hit.get("missing") is None
+            assert hit.get("missing", "???") == "???"

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -507,3 +507,41 @@ def test_span_eq_ne_consistency():
     diff_end = Span(1, 3, startchar=10, endchar=20)
     assert a != diff_end
     assert not (a == diff_end)
+
+
+def test_spannot_str_does_not_raise():
+    # gh#153: str() on a span query previously raised NotImplementedError
+    # from the base Query.__str__. It should now return a usable string
+    # (falling back to repr) rather than blowing up.
+    q = spans.SpanNot(
+        spans.SpanNear2([Term("text", "a"), Term("text", "b")], slop=2),
+        Term("text", "c"),
+    )
+    s = str(q)
+    assert "SpanNot" in s
+    assert s == repr(q)
+
+
+def test_spannot_search_when_excluded_span_missing():
+    # gh#153: searching with SpanNot where the excluded span does not match
+    # in a document raised IndexError ("tuple index out of range") because
+    # SpanNot._get_spans() called id() on an exhausted matcher.
+    schema = fields.Schema(path=fields.ID(stored=True),
+                           text=fields.TEXT(stored=True, phrase=True))
+    st = RamStorage()
+    ix = st.create_index(schema)
+    with ix.writer() as w:
+        # "seeking musical" present, excluded "seeking ... amount" absent
+        w.add_document(path="p1", text="seeking musical delight in the morning")
+        # excluded span present -> must be filtered out
+        w.add_document(path="p2", text="seeking musical amount of joy")
+
+    with ix.searcher() as s:
+        a = spans.SpanNear2([Term("text", "seeking"), Term("text", "musical")],
+                            slop=16, ordered=True, mindist=1)
+        b = spans.SpanNear2([Term("text", "seeking"), Term("text", "amount")],
+                            slop=3, ordered=True, mindist=1)
+        q = spans.SpanNot(a, b)
+        results = s.search(q, limit=None)
+        paths = sorted(hit["path"] for hit in results)
+        assert paths == ["p1"]

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -526,8 +526,9 @@ def test_spannot_search_when_excluded_span_missing():
     # gh#153: searching with SpanNot where the excluded span does not match
     # in a document raised IndexError ("tuple index out of range") because
     # SpanNot._get_spans() called id() on an exhausted matcher.
-    schema = fields.Schema(path=fields.ID(stored=True),
-                           text=fields.TEXT(stored=True, phrase=True))
+    schema = fields.Schema(
+        path=fields.ID(stored=True), text=fields.TEXT(stored=True, phrase=True)
+    )
     st = RamStorage()
     ix = st.create_index(schema)
     with ix.writer() as w:
@@ -537,10 +538,18 @@ def test_spannot_search_when_excluded_span_missing():
         w.add_document(path="p2", text="seeking musical amount of joy")
 
     with ix.searcher() as s:
-        a = spans.SpanNear2([Term("text", "seeking"), Term("text", "musical")],
-                            slop=16, ordered=True, mindist=1)
-        b = spans.SpanNear2([Term("text", "seeking"), Term("text", "amount")],
-                            slop=3, ordered=True, mindist=1)
+        a = spans.SpanNear2(
+            [Term("text", "seeking"), Term("text", "musical")],
+            slop=16,
+            ordered=True,
+            mindist=1,
+        )
+        b = spans.SpanNear2(
+            [Term("text", "seeking"), Term("text", "amount")],
+            slop=3,
+            ordered=True,
+            mindist=1,
+        )
         q = spans.SpanNot(a, b)
         results = s.search(q, limit=None)
         paths = sorted(hit["path"] for hit in results)


### PR DESCRIPTION
Fixes #153, reported by @BenitoKme with an excellent, reproducible bug report.

Three independent Whoosh 2.7.4 → `whoosh3` compatibility regressions, each with a regression test:

### 1. `SpanNot` search → `IndexError: tuple index out of range` (the blocker)
When the excluded (second) span did **not** match in a candidate document, `SpanNot._Matcher._get_spans()` called `.id()` on the exhausted "maybe" side of the underlying `AndMaybeMatcher`, which indexes into an empty positions tuple. Now guarded with `self.b.is_active()` — if there's nothing to exclude, all spans from the first query pass through. Verified the exclusion semantics still hold (documents where the excluded span *does* match are still filtered out).

### 2. `str(span_query)` → `NotImplementedError`
Span queries never overrode the base `Query.__str__`, which raises `NotImplementedError`. `repr()` worked but `str()`/`print()` did not. Span queries have no dedicated query-language syntax, so `SpanQuery.__str__` now falls back to the well-defined recursive `repr`.

### 3. `Hit.get()` missing
`hit.get("field", default)` — a standard dict-style accessor that worked in Whoosh 2.7.4 — raised `AttributeError`. Restored with the usual `dict.get` semantics.

### Tests
- `test_spannot_search_when_excluded_span_missing`
- `test_spannot_str_does_not_raise`
- `test_hit_get_dict_interface`

Full suite green (123 passed in the affected modules). Changelog updated under `[Unreleased]`.