### PR TITLE
ty: fix no-matching-overload and un-ignore in pyproject.toml

### DIFF
--- a/examples/rag_retriever.py
+++ b/examples/rag_retriever.py
@@ -152,7 +152,7 @@ def reciprocal_rank_fusion(rankings, k=60):
     for ranking in rankings:
         for rank, doc_id in enumerate(ranking):
             scores[doc_id] = scores.get(doc_id, 0.0) + 1.0 / (k + rank + 1)
-    return sorted(scores, key=scores.get, reverse=True)
+    return sorted(scores, key=lambda k: scores[k], reverse=True)
 
 
 def hybrid_search(ix, query, k=10):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,6 @@ rules.invalid-ignore-comment = "ignore"  # 1 instance
 rules.invalid-method-override = "ignore"  # 131 instances
 rules.invalid-return-type = "ignore"  # 28 instances
 rules.missing-argument = "ignore"  # 12 instances
-rules.no-matching-overload = "ignore"  # 2 instances
 rules.not-subscriptable = "ignore"  # 15 instances
 rules.too-many-positional-arguments = "ignore"  # 27 instances
 rules.unknown-argument = "ignore"  # 10 instances


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

This PR resolves the remaining `no-matching-overload` violation to help clear `pyproject.toml`.

Fixed one instance in `examples/rag_retriever.py` by replacing `key=scores.get` with `key=lambda k: scores[k]`. The type checker struggled with `dict.get` because its signature implies an `Optional` return type (which isn't strictly comparable for `sorted`), whereas direct indexing guarantees the correct type.

The rule has been successfully un-ignored in `pyproject.toml`.

## Related issues

References #121

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [ ] Added/updated tests for the change where it makes sense
- [ ] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](https://github.com/priya-sundaram-dev/whoosh/blob/main/CONTRIBUTING.md) guide