### PR TITLE
Ty: un-ignore invalid-return-type rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,6 @@ rules.invalid-argument-type = "ignore"  # 30 instances
 rules.invalid-assignment = "ignore"  # 21 instances
 rules.invalid-ignore-comment = "ignore"  # 1 instance
 rules.invalid-method-override = "ignore"  # 131 instances
-rules.invalid-return-type = "ignore"  # 28 instances
 rules.missing-argument = "ignore"  # 12 instances
 rules.not-subscriptable = "ignore"  # 15 instances
 rules.too-many-positional-arguments = "ignore"  # 27 instances

--- a/src/whoosh/analysis/analyzers.py
+++ b/src/whoosh/analysis/analyzers.py
@@ -64,11 +64,7 @@ class Analyzer(Composable):
         return f"{self.__class__.__name__}()"
 
     def __eq__(self, other: object) -> bool:
-        return (
-            other
-            and self.__class__ is other.__class__
-            and self.__dict__ == other.__dict__
-        )
+        return type(self) is type(other) and self.__dict__ == other.__dict__
 
     def __call__(self, value: str, **kwargs: Any) -> Iterator[Token]:
         raise NotImplementedError
@@ -122,7 +118,7 @@ class CompositeAnalyzer(Analyzer):
         return len(self.items)
 
     def __eq__(self, other: object) -> bool:
-        return other and self.__class__ is other.__class__ and self.items == other.items
+        return type(self) is type(other) and self.items == other.items
 
     def clean(self) -> None:
         for item in self.items:
@@ -136,7 +132,7 @@ class CompositeAnalyzer(Analyzer):
 # Functions that return composed analyzers
 
 
-def IDAnalyzer(lowercase: bool = False) -> Analyzer:
+def IDAnalyzer(lowercase: bool = False) -> Composable:
     """Deprecated, just use an IDTokenizer directly, with a LowercaseFilter if
     desired.
     """
@@ -147,7 +143,7 @@ def IDAnalyzer(lowercase: bool = False) -> Analyzer:
     return tokenizer
 
 
-def KeywordAnalyzer(lowercase: bool = False, commas: bool = False) -> Analyzer:
+def KeywordAnalyzer(lowercase: bool = False, commas: bool = False) -> Composable:
     """Parses whitespace- or comma-separated tokens.
 
     >>> ana = KeywordAnalyzer()
@@ -168,7 +164,7 @@ def KeywordAnalyzer(lowercase: bool = False, commas: bool = False) -> Analyzer:
     return tokenizer
 
 
-def RegexAnalyzer(expression: str = r"\w+(\.?\w+)*", gaps: bool = False) -> Analyzer:
+def RegexAnalyzer(expression: str = r"\w+(\.?\w+)*", gaps: bool = False) -> Composable:
     """Deprecated, just use a RegexTokenizer directly."""
 
     return RegexTokenizer(expression=expression, gaps=gaps)

--- a/src/whoosh/analysis/filters.py
+++ b/src/whoosh/analysis/filters.py
@@ -115,11 +115,7 @@ class Filter(Composable):
     """
 
     def __eq__(self, other: object) -> bool:
-        return (
-            other
-            and self.__class__ is other.__class__
-            and self.__dict__ == other.__dict__
-        )
+        return type(self) is type(other) and self.__dict__ == other.__dict__
 
     def __ne__(self, other: object) -> bool:
         return not self == other
@@ -180,11 +176,7 @@ class MultiFilter(Filter):
         self.filters = kwargs
 
     def __eq__(self, other: object) -> bool:
-        return (
-            other
-            and self.__class__ is other.__class__
-            and self.filters == other.filters
-        )
+        return type(self) is type(other) and self.filters == other.filters
 
     def __call__(self, tokens: Iterator[Token]) -> Iterable[Token]:
         # Only selects on the first token. If there are no tokens to filter
@@ -346,8 +338,7 @@ class StopFilter(Filter):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
             and self.stops == other.stops
             and self.min == other.min
             and self.renumber == other.renumber
@@ -425,8 +416,8 @@ class CharsetFilter(Filter):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
+            and self.__class__ == other.__class__
             and self.charmap == other.charmap
         )
 
@@ -483,8 +474,7 @@ class DelimitedAttributeFilter(Filter):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
             and self.delim == other.delim
             and self.attr == other.attr
             and self.default == other.default
@@ -541,8 +531,7 @@ class SubstitutionFilter(Filter):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
             and self.pattern == other.pattern
             and self.replacement == other.replacement
         )

--- a/src/whoosh/analysis/ngrams.py
+++ b/src/whoosh/analysis/ngrams.py
@@ -167,8 +167,7 @@ class NgramFilter(Filter):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
             and self.min == other.min
             and self.max == other.max
         )

--- a/src/whoosh/fields.py
+++ b/src/whoosh/fields.py
@@ -334,7 +334,7 @@ class FieldType:
         startexcl: bool,
         endexcl: bool,
         boost: float = 1.0,
-    ) -> Query:
+    ) -> Query | None:
         """
         When ``self_parsing()`` returns True, the query parser will call
         this method to parse range query text. If this method returns None

--- a/src/whoosh/formats.py
+++ b/src/whoosh/formats.py
@@ -76,11 +76,7 @@ class Format:
         self.options = options
 
     def __eq__(self, other: object) -> bool:
-        return (
-            other
-            and self.__class__ is other.__class__
-            and self.__dict__ == other.__dict__
-        )
+        return type(self) is type(other) and self.__dict__ == other.__dict__
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(boost={self.field_boost})"

--- a/src/whoosh/query/compound.py
+++ b/src/whoosh/query/compound.py
@@ -65,8 +65,7 @@ class CompoundQuery(qcore.Query):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
             and self.subqueries == other.subqueries
             and self.boost == other.boost
         )
@@ -529,12 +528,7 @@ class BinaryQuery(CompoundQuery):
         self.subqueries = (a, b)
 
     def __eq__(self, other: object) -> bool:
-        return (
-            other
-            and self.__class__ is other.__class__
-            and self.a == other.a
-            and self.b == other.b
-        )
+        return type(self) is type(other) and self.a == other.a and self.b == other.b
 
     def __hash__(self) -> int:
         return hash(self.__class__.__name__) ^ hash(self.a) ^ hash(self.b)

--- a/src/whoosh/query/positional.py
+++ b/src/whoosh/query/positional.py
@@ -75,8 +75,7 @@ class Sequence(compound.CompoundQuery):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and type(self) is type(other)
+            type(self) is type(other)
             and self.subqueries == other.subqueries
             and self.boost == other.boost
         )
@@ -194,8 +193,7 @@ class Phrase(qcore.Query):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
             and self.fieldname == other.fieldname
             and self.words == other.words
             and self.slop == other.slop

--- a/src/whoosh/query/ranges.py
+++ b/src/whoosh/query/ranges.py
@@ -28,7 +28,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from whoosh.query import compound, qcore, terms, wrappers
 from whoosh.util.times import datetime_to_long
@@ -52,8 +52,7 @@ class RangeMixin:
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
             and self.fieldname == other.fieldname
             and self.start == other.start
             and self.end == other.end
@@ -137,14 +136,17 @@ class RangeMixin:
         boost = max(self.boost, other.boost)
         constantscore = self.constantscore or other.constantscore
 
-        return self.__class__(
-            self.fieldname,
-            startval,
-            endval,
-            startexcl,
-            endexcl,
-            boost=boost,
-            constantscore=constantscore,
+        return cast(
+            "qcore.Query",
+            self.__class__(
+                self.fieldname,
+                startval,
+                endval,
+                startexcl,
+                endexcl,
+                boost=boost,
+                constantscore=constantscore,
+            ),
         )
 
 

--- a/src/whoosh/query/terms.py
+++ b/src/whoosh/query/terms.py
@@ -67,8 +67,7 @@ class Term(qcore.Query):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
             and self.fieldname == other.fieldname
             and self.text == other.text
             and self.boost == other.boost
@@ -290,8 +289,7 @@ class PatternQuery(MultiTerm):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
             and self.fieldname == other.fieldname
             and self.text == other.text
             and self.boost == other.boost
@@ -516,8 +514,7 @@ class FuzzyTerm(ExpandingTerm):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
             and self.fieldname == other.fieldname
             and self.text == other.text
             and self.maxdist == other.maxdist
@@ -555,7 +552,7 @@ class FuzzyTerm(ExpandingTerm):
             ^ hash(self.constantscore)
         )
 
-    def _btexts(self, ixreader: IndexReader) -> Iterable[bytes]:
+    def _btexts(self, ixreader: IndexReader) -> Iterable[Any]:
         return ixreader.terms_within(
             self.fieldname, self.text, self.maxdist, prefix=self.prefixlength
         )
@@ -586,8 +583,7 @@ class Variations(ExpandingTerm):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
             and self.fieldname == other.fieldname
             and self.text == other.text
             and self.boost == other.boost

--- a/src/whoosh/query/wrappers.py
+++ b/src/whoosh/query/wrappers.py
@@ -104,7 +104,7 @@ class Not(qcore.Query):
         self.boost = boost
 
     def __eq__(self, other: object) -> bool:
-        return other and self.__class__ is other.__class__ and self.query == other.query
+        return type(self) is type(other) and self.query == other.query
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({repr(self.query)})"
@@ -163,8 +163,7 @@ class ConstantScoreQuery(WrappingQuery):
 
     def __eq__(self, other: object) -> bool:
         return (
-            other
-            and self.__class__ is other.__class__
+            type(self) is type(other)
             and self.child == other.child
             and self.score == other.score
         )

--- a/src/whoosh/sorting.py
+++ b/src/whoosh/sorting.py
@@ -72,7 +72,9 @@ class FacetType:
 
         raise NotImplementedError
 
-    def map(self, default: type[FacetMap] | FacetMap | None = None) -> FacetMap:
+    def map(
+        self, default: type[FacetMap] | FacetMap | None = None
+    ) -> type[FacetMap] | FacetMap:
         t = self.maptype
         if t is None:
             t = default


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

This PR addresses the 28 violations of `invalid-return-type`, allowing us to un-ignore the rule in `pyproject.toml`. 

The fixes fall into a few architectural categories:
1. **AlwaysTruthy in `__eq__` methods**: Fixed multiple `__eq__` implementations in `analyzers.py` and `filters.py` that were returning `other and ...` (which evaluates to `None` if `other` is `None`, violating the `bool` return type). Replaced with `type(self) is type(other)` to guarantee a strict boolean return.
2. **Tokenizer vs Analyzer Inheritance**: Updated the return types of factory functions like `IDAnalyzer` and `KeywordAnalyzer`. They were annotated to return `Analyzer` but conditionally returned `Tokenizer`s. Changed the return type to their common base class, `Composable`.
3. **Union & Optional strictness**: 
   - Added `| None` to `fields.py` where a function explicitly returned `None`.
   - Updated `FacetMap.map` in `sorting.py` to correctly reflect that it can return the uninstantiated class `type[FacetMap]`.
4. **Casting**: Added `typing.cast("qcore.Query", ...)` in `RangeMixin.merge` since the linter couldn't infer the final class type from `self.__class__`.

The rule is now successfully un-ignored and fully enforced.

## Related issues

References #121

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [ ] Added/updated tests for the change where it makes sense
- [ ] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](https://github.com/priya-sundaram-dev/whoosh/blob/main/CONTRIBUTING.md) guide