### PR TITLE
Ty: un-ignore unused-type-ignore-comment rule

### DIFF
--- a/benchmark/dictionary.py
+++ b/benchmark/dictionary.py
@@ -36,7 +36,7 @@ class VulgarTongue(Spec):
         return schema
 
     def zcatalog_setup(self, cat):
-        from zcatalog import indexes  # type: ignore @UnresolvedImport
+        from zcatalog import indexes
 
         cat["head"] = indexes.FieldIndex(field_name="head")
         cat["body"] = indexes.TextIndex(field_name="body")

--- a/benchmark/enron.py
+++ b/benchmark/enron.py
@@ -6,7 +6,7 @@ from urllib.request import urlretrieve
 from zlib import compress, decompress
 
 try:
-    import xappy  # type: ignore
+    import xappy
 except ImportError:
     pass
 
@@ -164,7 +164,7 @@ class Enron(Spec):
         return conn
 
     def zcatalog_setup(self, cat):
-        from zcatalog import indexes  # type: ignore
+        from zcatalog import indexes
 
         for name in ("date", "frm"):
             cat[name] = indexes.FieldIndex(field_name=name)

--- a/benchmark/reuters.py
+++ b/benchmark/reuters.py
@@ -22,7 +22,7 @@ class Reuters(Spec):
         return schema
 
     def zcatalog_setup(self, cat):
-        from zcatalog import indexes  # type: ignore @UnresolvedImport
+        from zcatalog import indexes
 
         cat["id"] = indexes.FieldIndex(field_name="id")
         cat["headline"] = indexes.TextIndex(field_name="headline")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,6 @@ rules.unknown-argument = "ignore"  # 10 instances
 rules.unresolved-attribute = "ignore"  # 347 instances
 rules.unresolved-import = "ignore"  # 29 instances
 rules.unsupported-operator = "ignore"  # 27 instances
-rules.unused-type-ignore-comment = "ignore"  # 19 instances
 
 [tool.pytest]
 # ==========================================================================

--- a/src/whoosh/analysis/morph.py
+++ b/src/whoosh/analysis/morph.py
@@ -197,7 +197,7 @@ class PyStemmerFilter(StemFilter):
         library.
         """
 
-        import Stemmer  # type: ignore @UnresolvedImport
+        import Stemmer
 
         return Stemmer.algorithms()
 
@@ -205,7 +205,7 @@ class PyStemmerFilter(StemFilter):
         return None
 
     def _get_stemmer_fn(self):
-        import Stemmer  # type: ignore @UnresolvedImport
+        import Stemmer
 
         stemmer = Stemmer.Stemmer(self.lang)
         stemmer.maxCacheSize = self.cachesize

--- a/src/whoosh/automata/fst.py
+++ b/src/whoosh/automata/fst.py
@@ -41,7 +41,7 @@ use in (at least) spell checking.
 import copy
 import sys
 from array import array
-from hashlib import sha1  # type: ignore @UnresolvedImport
+from hashlib import sha1
 from io import BytesIO
 
 from whoosh.filedb.structfile import StructFile

--- a/src/whoosh/codec/whoosh2.py
+++ b/src/whoosh/codec/whoosh2.py
@@ -31,7 +31,7 @@ from array import array
 from binascii import crc32
 from collections import defaultdict
 from decimal import Decimal
-from hashlib import md5  # type: ignore @UnresolvedImport
+from hashlib import md5
 from pickle import dumps, loads
 from struct import Struct
 

--- a/src/whoosh/filedb/filetables.py
+++ b/src/whoosh/filedb/filetables.py
@@ -33,7 +33,7 @@ D. J. Bernstein's CDB format (http://cr.yp.to/cdb.html).
 import os
 import struct
 from binascii import crc32
-from hashlib import md5  # type: ignore @UnresolvedImport
+from hashlib import md5
 
 from whoosh.system import _INT_SIZE, emptybytes
 from whoosh.util.numlists import GrowableArray

--- a/src/whoosh/filedb/gae.py
+++ b/src/whoosh/filedb/gae.py
@@ -20,8 +20,8 @@ To open an existing index::
 import time
 from io import BytesIO
 
-from google.appengine.api import memcache  # type: ignore @UnresolvedImport
-from google.appengine.ext import db  # type: ignore @UnresolvedImport
+from google.appengine.api import memcache
+from google.appengine.ext import db
 
 from whoosh.filedb.filestore import ReadOnlyError, Storage
 from whoosh.filedb.structfile import StructFile

--- a/src/whoosh/support/bench.py
+++ b/src/whoosh/support/bench.py
@@ -34,20 +34,20 @@ from whoosh import index, qparser, query, scoring
 from whoosh.util import find_object, now
 
 try:
-    import xappy  # type: ignore
+    import xappy
 except ImportError:
     pass
 try:
-    import xapian  # type: ignore
+    import xapian
 except ImportError:
     pass
 try:
-    import pysolr  # type: ignore
+    import pysolr
 except ImportError:
     pass
 
 try:
-    from persistent import Persistent  # type: ignore
+    from persistent import Persistent
 
     class ZDoc(Persistent):
         def __init__(self, d):
@@ -343,11 +343,11 @@ class SolrModule(Module):
 
 class ZcatalogModule(Module):
     def indexer(self, **kwargs):
-        import transaction  # type: ignore # type: ignore @UnresolvedImport
-        from zcatalog import catalog  # type: ignore # type: ignore @UnresolvedImport
-        from ZODB.DB import DB  # type: ignore # type: ignore @UnresolvedImport
+        import transaction
+        from zcatalog import catalog
+        from ZODB.DB import DB
         from ZODB.FileStorage import (
-            FileStorage,  # type: ignore # type: ignore @UnresolvedImport
+            FileStorage,
         )
 
         directory = os.path.join(self.options.dir, f"{self.options.indexname}_zcatalog")
@@ -373,21 +373,21 @@ class ZcatalogModule(Module):
         self.cat.index_doc(doc)
         self.zcatalog_count += 1
         if self.zcatalog_count >= 100:
-            import transaction  # type: ignore # type: ignore @UnresolvedImport
+            import transaction
 
             transaction.commit()
             self.zcatalog_count = 0
 
     def finish(self, **kwargs):
-        import transaction  # type: ignore # type: ignore @UnresolvedImport
+        import transaction
 
         transaction.commit()
         del self.zcatalog_count
 
     def searcher(self):
-        from ZODB.DB import DB  # type: ignore # type: ignore @UnresolvedImport
+        from ZODB.DB import DB
         from ZODB.FileStorage import (
-            FileStorage,  # type: ignore # type: ignore @UnresolvedImport
+            FileStorage,
         )
 
         path = os.path.join(
@@ -421,7 +421,7 @@ class NucularModule(Module):
     def indexer(self, create=True):
         import shutil
 
-        from nucular import Nucular  # type: ignore # type: ignore @UnresolvedImport
+        from nucular import Nucular
 
         directory = os.path.join(self.options.dir, f"{self.options.indexname}_nucular")
         if create:
@@ -452,7 +452,7 @@ class NucularModule(Module):
         self.archive.cleanUp()
 
     def searcher(self):
-        from nucular import Nucular  # type: ignore # type: ignore @UnresolvedImport
+        from nucular import Nucular
 
         directory = os.path.join(
             self.options.directory, f"{self.options.indexname}_nucular"

--- a/src/whoosh/util/filelock.py
+++ b/src/whoosh/util/filelock.py
@@ -90,7 +90,7 @@ class FcntlLock(LockBase):
     """File lock based on UNIX-only fcntl module."""
 
     def acquire(self, blocking=False):
-        import fcntl  # type: ignore @UnresolvedImport
+        import fcntl
 
         flags = os.O_CREAT | os.O_WRONLY
         self.fd = os.open(self.filename, flags)
@@ -115,7 +115,7 @@ class FcntlLock(LockBase):
         if self.fd is None:
             raise Exception("Lock was not acquired")
 
-        import fcntl  # type: ignore @UnresolvedImport
+        import fcntl
 
         fcntl.flock(self.fd, fcntl.LOCK_UN)
         os.close(self.fd)
@@ -126,7 +126,7 @@ class MsvcrtLock(LockBase):
     """File lock based on Windows-only msvcrt module."""
 
     def acquire(self, blocking=False):
-        import msvcrt  # type: ignore @UnresolvedImport
+        import msvcrt
 
         flags = os.O_CREAT | os.O_WRONLY
         mode = msvcrt.LK_NBLCK
@@ -146,7 +146,7 @@ class MsvcrtLock(LockBase):
             return False
 
     def release(self):
-        import msvcrt  # type: ignore @UnresolvedImport
+        import msvcrt
 
         if self.fd is None:
             raise Exception("Lock was not acquired")

--- a/stress/test_bigtable.py
+++ b/stress/test_bigtable.py
@@ -1,6 +1,6 @@
 from random import randint, shuffle
 
-from nose.tools import assert_equal  # type: ignore @UnresolvedImport
+from nose.tools import assert_equal
 
 from whoosh.filedb.filetables import HashReader, HashWriter
 from whoosh.util.testing import TempStorage

--- a/stress/test_hugeindex.py
+++ b/stress/test_hugeindex.py
@@ -1,6 +1,6 @@
 import struct
 
-from nose.tools import assert_equal  # type: ignore @UnresolvedImport
+from nose.tools import assert_equal
 
 from whoosh import formats
 from whoosh.filedb.filepostings import FilePostingReader, FilePostingWriter


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

This PR addresses the 19 instances of `unused-type-ignore-comment`, clearing the way to un-ignore the rule in `pyproject.toml`. 

The cleanup was purely mechanical:
- Removed obsolete `# type: ignore @UnresolvedImport` directives (mostly in `benchmark/` scripts) which are no longer necessary for modern type checkers.
- Removed blanket `# type: ignore` comments that `ty` flagged as unused/redundant.

The rule is now successfully un-ignored and enforced.

## Related issues

References #121

## Checklist

- [x] Tests pass locally (`pytest tests/`)
- [ ] Added/updated tests for the change where it makes sense
- [ ] Updated docs / CHANGELOG if user-facing
- [x] I have read the [CONTRIBUTING](https://github.com/priya-sundaram-dev/whoosh/blob/main/CONTRIBUTING.md) guide