### PR TITLE
typing: concrete parameter types where determinable (revised per review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ All notable changes to this project are documented here. This project follows
   targeted `# ty: ignore[unknown-argument]` on mixin `self.__class__(...)`
   re-instantiations where the concrete constructor can't be known statically.
   Thanks to @SantiagoDaleffe.
+- Replaced a few opaque `Any` parameter annotations with the concrete types the
+  code and docstrings already document, so editors and type checkers can help
+  callers: `Query.matcher(context=...)` is now `SearchContext | None`,
+  `FieldType.sortable_terms(ixreader=...)` and `Expander(ixreader=...)` take an
+  `IndexReader`, and `BitSet`/`OnDiskBitSet`'s on-disk methods take a
+  `StructFile`. The concrete `ixreader` type also surfaced that the base
+  `FieldType.sortable_terms` returns an `Iterable[bytes]` (from
+  `reader.lexicon()`), not an `Iterator[bytes]`; the annotation is corrected.
+  Genuinely polymorphic boundaries — term text and stored field values, which
+  legitimately accept `str`, numbers, `bytes`, … — keep `Any`, since a narrower
+  type there would be wrong. Thanks to @cclauss for the review that prompted
+  this analysis.
 
 ## [3.49.0] - 2026-08-28
 

--- a/src/whoosh/classify.py
+++ b/src/whoosh/classify.py
@@ -39,6 +39,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from whoosh.reading import IndexReader
+
 
 # Expansion models
 
@@ -117,7 +119,7 @@ class Expander:
 
     def __init__(
         self,
-        ixreader: Any,
+        ixreader: IndexReader,
         fieldname: str,
         model: type[ExpansionModel] | ExpansionModel = Bo1Model,
     ) -> None:

--- a/src/whoosh/fields.py
+++ b/src/whoosh/fields.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from whoosh.analysis import Analyzer, Token
     from whoosh.formats import Format
     from whoosh.query import Query
+    from whoosh.reading import IndexReader
 
 from whoosh import analysis, columns, formats
 from whoosh.system import emptybytes, pack_byte
@@ -290,7 +291,7 @@ class FieldType:
         else:
             self.column_type = None
 
-    def sortable_terms(self, ixreader: Any, fieldname: str) -> Iterator[bytes]:
+    def sortable_terms(self, ixreader: IndexReader, fieldname: str) -> Iterable[bytes]:
         """
         Returns an iterator of the "sortable" tokens in the given reader and
         field. These values can be used for sorting. The default implementation
@@ -900,7 +901,7 @@ class NUMERIC(FieldType):
             fieldname, start, end, startexcl, endexcl, boost=boost
         )
 
-    def sortable_terms(self, ixreader: Any, fieldname: str) -> Iterator[bytes]:
+    def sortable_terms(self, ixreader: IndexReader, fieldname: str) -> Iterator[bytes]:
         zero = b"\x00"
         for token in ixreader.lexicon(fieldname):
             if token[0:1] != zero:

--- a/src/whoosh/idsets.py
+++ b/src/whoosh/idsets.py
@@ -9,9 +9,12 @@ from array import array
 from bisect import bisect_left, bisect_right
 from collections.abc import Callable, Collection, Iterable, Iterator
 from itertools import zip_longest
-from typing import Any, Union
+from typing import TYPE_CHECKING, Union
 
 from whoosh.util.numeric import bytes_for_bits
+
+if TYPE_CHECKING:
+    from whoosh.filedb.structfile import StructFile
 
 # Anything that can stand in for "another set of doc ids" in the combining and
 # comparison methods below: either a :class:`DocIdSet`, or any built-in
@@ -513,7 +516,7 @@ class OnDiskBitSet(BaseBitSet):
     [1, 2, 7, 10, 15]
     """
 
-    def __init__(self, dbfile: Any, basepos: int, bytecount: int) -> None:
+    def __init__(self, dbfile: StructFile, basepos: int, bytecount: int) -> None:
         """
         :param dbfile: a :class:`~whoosh.filedb.structfile.StructFile` object
             to read from.
@@ -620,7 +623,7 @@ class BitSet(BaseBitSet):
         obj._trim()
         return obj
 
-    def to_disk(self, dbfile: Any) -> int:
+    def to_disk(self, dbfile: StructFile) -> int:
         dbfile.write_array(self.bits)
         return len(self.bits)
 
@@ -631,7 +634,7 @@ class BitSet(BaseBitSet):
         return b
 
     @classmethod
-    def from_disk(cls, dbfile: Any, bytecount: int) -> BitSet:
+    def from_disk(cls, dbfile: StructFile, bytecount: int) -> BitSet:
         return cls.from_bytes(dbfile.read_array("B", bytecount))
 
     def copy(self) -> BitSet:

--- a/src/whoosh/query/qcore.py
+++ b/src/whoosh/query/qcore.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from whoosh.analysis.acore import Token
     from whoosh.matching import Matcher
     from whoosh.reading import IndexReader
-    from whoosh.searching import Searcher
+    from whoosh.searching import SearchContext, Searcher
 
 # Exceptions
 
@@ -546,7 +546,9 @@ class Query:
 
         return self.estimate_size(ixreader)
 
-    def matcher(self, searcher: Searcher, context: Any = None) -> Matcher:
+    def matcher(
+        self, searcher: Searcher, context: SearchContext | None = None
+    ) -> Matcher:
         """Returns a :class:`~whoosh.matching.Matcher` object you can use to
         retrieve documents and scores matching this query.
 


### PR DESCRIPTION
Revised after @cclauss's review. The original version enabled `ANN401` and swapped `Any` → `object` wholesale; as you noted, that helps neither readers nor type checkers, since everything is an `object`.

Reworked to do the analysis instead — annotate the parameters whose type the code and docstrings already pin down, and keep `Any` where the value is genuinely polymorphic:

**Now concretely typed:**
- `Query.matcher(context=...)` → `SearchContext | None`
- `FieldType.sortable_terms(ixreader=...)` and `Expander(ixreader=...)` → `IndexReader`
- `BitSet` / `OnDiskBitSet` on-disk methods (`dbfile=...`) → `StructFile` (already documented as such in the docstrings)

The concrete `ixreader` type also surfaced a latent inaccuracy: the base `FieldType.sortable_terms` returns `reader.lexicon(...)`, which is `Iterable[bytes]`, not the annotated `Iterator[bytes]` — corrected.

**Deliberately kept `Any`:** term text and stored field values. `Term('price', 50)` and stored `NUMERIC` values are legitimately non-`str` (the test suite constructs `Term`s with ints), so `str` would be too narrow and `Any` is the honest type — exactly the "might be impossible to determine" case you described. For the same reason I dropped the blanket ANN401 gate; enforcing it would just push those honest `Any`s back to `object` or a wall of `# noqa`.

Green locally: `ruff check`, `ruff format --check`, `ty check`, `mypy` smoke, `pytest` (883 passed).