### PR TITLE
ci(publish): PyPI Trusted Publishing (OIDC) + PEP 740 build attestations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,14 +47,18 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
+      url: https://pypi.org/p/whoosh3
+    # Trusted Publishing (OIDC): mint a short-lived token per run instead of a
+    # long-lived PyPI API secret, and let the action attach PEP 740 build
+    # attestations so anyone can verify the artifacts came from this workflow.
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
       - name: Publish
-        # TODO: Use Trusted Publishing and remove PYPI_API_TOKEN and the `zizmor: ignore`.
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # zizmor: ignore[use-trusted-publishing] v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true


### PR DESCRIPTION
## What

Switches the PyPI upload step from a long-lived `PYPI_API_TOKEN` secret to **GitHub OIDC Trusted Publishing**, and turns on **PEP 740 build attestations**.

## Why

A stored API token is a standing supply-chain risk: if it leaks, anyone can push a release. Trusted Publishing removes the secret entirely — the `publish` job requests a short-lived OIDC `id-token`, and `gh-action-pypi-publish` exchanges it for a per-run token that PyPI scopes to *this* workflow in *this* repo. With `id-token: write`, the action also attaches PEP 740 attestations, so every wheel/sdist on PyPI can be cryptographically verified back to the exact workflow run and git tag that built it.

## Changes

- `publish` job: add `permissions: id-token: write`, drop the `password:` input and the `zizmor: ignore` on the action pin.
- Add `environment.url` for the deployment link.
- PyPI side: trusted publisher already configured for `priya-sundaram-dev/whoosh` → `publish.yml` in the `pypi` environment, so the next release publishes with no secret and with attestations.

## Verification

Next tagged release will show a green 'Publish' job with no `PYPI_API_TOKEN` and a 'Provenance' / attestations link on the PyPI file listing. The `PYPI_API_TOKEN` secret can then be deleted.