### PR TITLE
fix(dateparse): honor DateParser.date_from overrides for range bounds (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Fixed
+- `DateParser.date_from` overrides are now honored for bracketed range bounds,
+  not just single/keyword values (#161). Previously `DateParserPlugin.range_to_dt`
+  reached past the configured parser to the bare grammar object, so any
+  customization a `DateParser` subclass added in its own `date_from` (timezone
+  normalization, clamping, logging, …) applied to `added:2020-06-15` but was
+  silently skipped for both bounds of `added:[2020-06-15 TO 2020-07-15]`.
+  Bound parsing now routes through `DateParser.date_from` via a new
+  `disambiguate=False` seam that preserves the "parse each bound raw,
+  disambiguate the whole span together" contract `range_to_dt` depends on.
+  Overrides predating the seam (a fixed signature without `disambiguate`/
+  `**kwargs`) fall back to the previous raw-grammar path, so they keep working
+  unchanged rather than raising. Surfaced by the differential test suite of
+  [`stumpylog/whoosh-compat`](https://github.com/stumpylog/whoosh-compat)
+  (`DIVERGENCES.md`, entry 12) — thanks for the careful cross-checking.
+
 ## [3.49.1] - 2026-08-29
 
 ### Fixed

--- a/src/whoosh/qparser/dateparse.py
+++ b/src/whoosh/qparser/dateparse.py
@@ -25,6 +25,7 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
+import inspect
 import re
 import sys
 from datetime import datetime, timedelta, timezone
@@ -652,7 +653,20 @@ class DateParser:
 
         return (d, newpos)
 
-    def date_from(self, text, basedate=None, pos=0, debug=-9999, toend=True):
+    def date_from(
+        self, text, basedate=None, pos=0, debug=-9999, toend=True, disambiguate=True
+    ):
+        """Parse ``text`` into an ``adatetime``/``timespan``/``datetime``.
+
+        :param toend: wrap the grammar in :class:`ToEnd` so the whole string
+            must be consumed (the default for single values).
+        :param disambiguate: when true (default) resolve the parsed result
+            against ``basedate`` before returning. Range-bound parsing passes
+            ``disambiguate=False`` so the raw bounds can be disambiguated
+            together as a span (see ``DateParserPlugin.range_to_dt``);
+            subclasses that override ``date_from`` should forward this flag so
+            their customization applies to range bounds too (issue #161).
+        """
         if basedate is None:
             basedate = datetime.now(tz=timezone.utc)
 
@@ -661,7 +675,7 @@ class DateParser:
             parser = ToEnd(parser)
 
         d = parser.date_from(text, basedate, pos=pos, debug=debug)
-        if isinstance(d, (adatetime, timespan)):
+        if disambiguate and isinstance(d, (adatetime, timespan)):
             d = d.disambiguated(basedate)
         return d
 
@@ -859,16 +873,45 @@ class DateParserPlugin(plugins.Plugin):
         n.endchar = node.endchar
         return n
 
+    def _bound_from(self, text):
+        """Parse a single range bound.
+
+        Routes through the configured ``DateParser.date_from`` (rather than the
+        bare grammar) so that subclass overrides — tz normalization, clamping,
+        logging, … — apply to range bounds as well as single values (issue
+        #161). The ``disambiguate=False``/``toend=False`` seam preserves the
+        "parse each bound raw, disambiguate the whole span later" contract that
+        :meth:`range_to_dt` relies on.
+
+        Overrides that predate this seam (a fixed signature without
+        ``disambiguate``/``**kwargs``) can't accept the flag; for those we fall
+        back to the pre-#161 raw-grammar path so they keep working unchanged
+        rather than raising ``TypeError``.
+        """
+        date_from = self.dateparser.date_from
+        try:
+            params = inspect.signature(date_from).parameters
+            supports_seam = "disambiguate" in params or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+            )
+        except (TypeError, ValueError):
+            supports_seam = False
+
+        if supports_seam:
+            return date_from(
+                text, self.basedate, toend=False, disambiguate=False
+            )
+        return self.dateparser.get_parser().date_from(text, self.basedate)
+
     def range_to_dt(self, node):
         start = end = None
-        dp = self.dateparser.get_parser()
 
         if node.start:
-            start = dp.date_from(node.start, self.basedate)
+            start = self._bound_from(node.start)
             if start is None:
                 return self.errorize(node.start, node)
         if node.end:
-            end = dp.date_from(node.end, self.basedate)
+            end = self._bound_from(node.end)
             if end is None:
                 return self.errorize(node.end, node)
 

--- a/src/whoosh/qparser/dateparse.py
+++ b/src/whoosh/qparser/dateparse.py
@@ -898,9 +898,7 @@ class DateParserPlugin(plugins.Plugin):
             supports_seam = False
 
         if supports_seam:
-            return date_from(
-                text, self.basedate, toend=False, disambiguate=False
-            )
+            return date_from(text, self.basedate, toend=False, disambiguate=False)
         return self.dateparser.get_parser().date_from(text, self.basedate)
 
     def range_to_dt(self, node):

--- a/tests/test_dateparse.py
+++ b/tests/test_dateparse.py
@@ -577,3 +577,78 @@ def test_disambiguated_default_basedate():
         adatetime(year=1970, month=10), adatetime(month=12, day=8)
     ).disambiguated(bd)
     assert d2.end.year == 2020
+
+
+#
+# Regression tests for issue #161: DateParser.date_from overrides must apply
+# to bracketed range bounds, not just single/keyword values.
+#
+
+
+def _make_qp(dateparser):
+    from whoosh.fields import DATETIME, ID, Schema
+    from whoosh.qparser import QueryParser
+    from whoosh.qparser.dateparse import DateParserPlugin
+
+    schema = Schema(id=ID(stored=True), added=DATETIME)
+    qp = QueryParser("id", schema)
+    qp.add_plugin(
+        DateParserPlugin(
+            basedate=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            dateparser=dateparser,
+        )
+    )
+    return qp
+
+
+def test_161_seam_override_runs_for_range_bounds():
+    """An override that adopts the disambiguate seam runs for both bounds."""
+    calls = []
+
+    class SeamParser(English):
+        def date_from(self, text, basedate=None, **kwargs):
+            calls.append(text)
+            return super().date_from(text, basedate, **kwargs)
+
+    qp = _make_qp(SeamParser())
+
+    calls.clear()
+    qp.parse("added:2020-06-15")
+    assert calls == ["2020-06-15"]
+
+    calls.clear()
+    qp.parse("added:[2020-06-15 to 2020-07-15]")
+    assert calls == ["2020-06-15", "2020-07-15"]
+
+
+def test_161_legacy_override_falls_back_without_error():
+    """A pre-seam fixed-signature override must not raise on range bounds."""
+    calls = []
+
+    class LegacyParser(English):
+        def date_from(self, text, basedate=None, pos=0, debug=-9999, toend=True):
+            calls.append(text)
+            return super().date_from(
+                text, basedate, pos=pos, debug=debug, toend=toend
+            )
+
+    qp = _make_qp(LegacyParser())
+
+    calls.clear()
+    # Must parse without TypeError; legacy overrides keep pre-#161 behavior
+    # (invoked for single values, bypassed for bounds via the raw-grammar
+    # fallback), but crucially they do not break.
+    q = qp.parse("added:[2020-06-15 to 2020-07-15]")
+    assert q is not None
+    assert calls == []
+
+
+def test_161_range_semantics_unchanged_for_base_parser():
+    """The base DateParser produces the same span as before the seam."""
+    qp = _make_qp(English())
+    q = qp.parse("added:[2020-06-15 to 2020-07-15]")
+    # start floored to the day, end ceiled to the day
+    assert q.startdate == datetime(2020, 6, 15, 0, 0, 0, 0, tzinfo=timezone.utc)
+    assert q.enddate == datetime(
+        2020, 7, 15, 23, 59, 59, 999999, tzinfo=timezone.utc
+    )

--- a/tests/test_dateparse.py
+++ b/tests/test_dateparse.py
@@ -628,9 +628,7 @@ def test_161_legacy_override_falls_back_without_error():
     class LegacyParser(English):
         def date_from(self, text, basedate=None, pos=0, debug=-9999, toend=True):
             calls.append(text)
-            return super().date_from(
-                text, basedate, pos=pos, debug=debug, toend=toend
-            )
+            return super().date_from(text, basedate, pos=pos, debug=debug, toend=toend)
 
     qp = _make_qp(LegacyParser())
 
@@ -649,6 +647,4 @@ def test_161_range_semantics_unchanged_for_base_parser():
     q = qp.parse("added:[2020-06-15 to 2020-07-15]")
     # start floored to the day, end ceiled to the day
     assert q.startdate == datetime(2020, 6, 15, 0, 0, 0, 0, tzinfo=timezone.utc)
-    assert q.enddate == datetime(
-        2020, 7, 15, 23, 59, 59, 999999, tzinfo=timezone.utc
-    )
+    assert q.enddate == datetime(2020, 7, 15, 23, 59, 59, 999999, tzinfo=timezone.utc)


### PR DESCRIPTION
Fixes #161.

## Problem

A `DateParser.date_from` override is honored for single/keyword date values but silently bypassed for bracketed range bounds. `DateParserPlugin.text_to_dt` routes single values through the configured parser, but `range_to_dt` reached past it to the bare grammar object:

```python
dp = self.dateparser.get_parser()      # -> self.all, the raw grammar
start = dp.date_from(node.start, ...)  # a DateParser.date_from override never runs
```

So any customization a subclass adds in its own `date_from` (tz normalization, clamping, logging, …) applied to `added:2020-06-15` but not to either bound of `added:[2020-06-15 TO 2020-07-15]`.

## Fix

`range_to_dt` now parses each bound through `DateParser.date_from`. Because bound parsing must *not* disambiguate each bound early (the span is disambiguated together afterward, with asymmetric start/end semantics), `date_from` gains a `disambiguate=False` seam (and already had `toend=False`). For the base parser this yields a result identical to the old raw-grammar call.

Overrides that predate the seam — a fixed signature without `disambiguate`/`**kwargs` — cannot accept the flag; a small `_bound_from` helper detects that via signature inspection and falls back to the previous raw-grammar path, so those overrides keep working unchanged rather than raising `TypeError`. New/updated overrides that accept the seam get invoked for bounds too.

## Tests

- override adopting the seam runs for both bounds (the reported behavior, now fixed)
- legacy fixed-signature override parses a range without error (fallback)
- base `DateParser` range span is unchanged (`2020-06-15 00:00` → `2020-07-15 23:59:59.999999` UTC)

Full suite + ruff green.

## Credit

Surfaced by the differential test suite of [`stumpylog/whoosh-compat`](https://github.com/stumpylog/whoosh-compat) (`DIVERGENCES.md`, entry 12).