### PR TITLE
fix(qparser): recognize range 'TO' separator only as a whole word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Fixed
+- `RangePlugin` now recognizes the `TO` range separator only as a whole word,
+  never inside an adjacent token. The tagger's regex matched a bare `[Tt][Oo]`
+  with no word-boundary requirement, so the "to" that *starts* an end value
+  was mistaken for the separator: `[TO today]` misparsed as start=`"TO"`/
+  end=`"day"` (instead of an open-start range up to `today`), and
+  `[total 5]` — which contains no real separator at all — became a garbage
+  empty-start range with end `"tal 5"` (on a DATE field the captured `"TO"`
+  even raised `"'TO' is not a parseable date"`). The separator is now matched
+  as `\b[Tt][Oo]\b`, so genuine ranges (`[a TO b]`, `[TO b]`, `[into TO 5]`,
+  quoted and exclusive bounds) parse unchanged while these mid-word
+  lookalikes no longer tag as ranges. Surfaced by the differential test suite
+  of [`stumpylog/whoosh-compat`](https://github.com/stumpylog/whoosh-compat)
+  (`DIVERGENCES.md`, entry 56) — thanks for the careful cross-checking.
+
 ## [3.49.2] - 2026-09-01
 
 ### Fixed

--- a/src/whoosh/qparser/plugins.py
+++ b/src/whoosh/qparser/plugins.py
@@ -871,9 +871,9 @@ class RangePlugin(Plugin):
     (?P<start>
         ('[^']*?'\s+)             # single-quoted
         |                         # or
-        ([^\]}]+?(?=[Tt][Oo]))    # everything until "to"
+        ([^\]}]+?(?=\b[Tt][Oo]\b))  # everything until word "to"
     )?
-    [Tt][Oo]                      # "to"
+    \b[Tt][Oo]\b                  # "to" as a whole word
     (?P<end>
         (\s+'[^']*?')             # single-quoted
         |                         # or

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -39,6 +39,35 @@ def test_range():
     assert repr(p.process("[to]")) == "<AndGroup <None:[None None]>>"
 
 
+def test_range_to_separator_word_boundary():
+    # Regression: the "TO" range separator must be recognized only as a
+    # whole word, never inside an adjacent token. Previously the tagger's
+    # bare ``[Tt][Oo]`` matched the "to" that starts "today"/"total"/etc.,
+    # so ``[TO today]`` misparsed as start="TO", end="day" and
+    # ``[total 5]`` became a garbage empty-start range with end="tal 5".
+    # Surfaced by stumpylog/whoosh-compat's differential suite (entry 56).
+    p = default.QueryParser(
+        "t", None, [plugins.WhitespacePlugin(), plugins.RangePlugin()]
+    )
+
+    # A bound-less start whose end value merely *begins* with "to":
+    # a proper open-start range, not "TO"+"day".
+    assert repr(p.process("[TO today]")) == "<AndGroup <None:[None 'today']>>"
+
+    # No genuine "TO" separator at all -> not a range. "total" contains
+    # "to" but not at a word boundary, so nothing is tagged as a range.
+    ns = p.process("[total 5]")
+    assert "None:[" not in repr(ns)
+
+    # A start value that itself contains "to" as a substring ("into")
+    # followed by a real "TO" separator still parses as a range.
+    assert repr(p.process("[into TO 5]")) == "<AndGroup <None:['into' '5']>>"
+
+    # Ordinary ranges are unaffected.
+    assert repr(p.process("[a TO b]")) == "<AndGroup <None:['a' 'b']>>"
+    assert repr(p.process("[TO b]")) == "<AndGroup <None:[None 'b']>>"
+
+
 def test_sq_range():
     p = default.QueryParser(
         "t",


### PR DESCRIPTION
## Problem

`RangePlugin`'s tagger recognized the `TO` range separator with a bare `[Tt][Oo]` and **no word-boundary requirement**, so the "to" that *starts* an adjacent token was mistaken for the separator:

```python
>>> qp.parse('[TO today]')   # BEFORE
TermRange(None, 'TO', 'day')     # garbage: start='TO', end='day'
>>> qp.parse('title:[total 5]')  # BEFORE — no real 'TO' anywhere
TermRange('title', None, 'tal 5')  # garbage empty-start range
```

On a DATE field the captured `"TO"` even raises `"'TO' is not a parseable date"`.

## Fix

Match the separator as `\b[Tt][Oo]\b` (word-bounded) in both the start-bound lookahead and the literal token. Genuine ranges are unaffected:

```python
>>> qp.parse('[TO today]')      # open-start range up to 'today'
TermRange(None, None, 'today')
>>> qp.parse('title:[total 5]') # no longer a range at all
Term('title', 'total')
>>> qp.parse('[into TO 5]')     # 'into' contains 'to' but a real TO follows
TermRange(None, 'into', '5')
```

`[a TO b]`, `[TO b]`, quoted bounds (`['a b' TO 'c d']`) and exclusive brackets all parse exactly as before — normal ranges always have a word boundary around `TO`.

## Tests

New `test_range_to_separator_word_boundary` in `tests/test_parsing.py`; full suite green (890 passed, 3 skipped).

## Credit

Surfaced by the differential test suite of [`stumpylog/whoosh-compat`](https://github.com/stumpylog/whoosh-compat) (`DIVERGENCES.md`, entry 56) — thanks for the careful cross-checking.