### PR TITLE
fix(qparser): keep all text from consecutive unknown-field candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to this project are documented here. This project follows
 ## [Unreleased]
 
 ### Fixed
+- `FieldsPlugin` no longer drops text when a query contains two or more
+  consecutive `word:` runs that don't name a real field. `do_fieldnames`
+  tracked only the most recently seen rejected candidate, so in a run like
+  `aa:bb:cc` (neither `aa` nor `bb` a field) the first candidate's text was
+  silently discarded and the query collapsed to `bb:cc`, with the user's
+  `aa:` gone without a trace. All consecutive rejected candidates are now
+  accumulated in order before being folded back onto the following term.
+  The same change fixes a companion span bug: after a demoted candidate was
+  merged into the surviving node's text, that node's `startchar` still
+  pointed at its own original position, so `endchar - startchar` no longer
+  matched `len(text)`; the span is now widened to cover the whole merged
+  run. Surfaced by the differential test suite of
+  [`stumpylog/whoosh-compat`](https://github.com/stumpylog/whoosh-compat)
+  (`DIVERGENCES.md`, entry 57).
 - `RangePlugin` now recognizes the `TO` range separator only as a whole word,
   never inside an adjacent token. The tagger's regex matched a bare `[Tt][Oo]`
   with no word-boundary requirement, so the "to" that *starts* an end value

--- a/src/whoosh/qparser/plugins.py
+++ b/src/whoosh/qparser/plugins.py
@@ -384,6 +384,21 @@ class FieldsPlugin(TaggingPlugin):
     def filters(self, parser):
         return [(self.do_fieldnames, 100)]
 
+    @staticmethod
+    def _merge_field_nodes(field_nodes):
+        """Convert a run of one or more rejected ``FieldnameNode``\\ s into a
+        single word node carrying all of their literal text, with a span that
+        covers the whole run (first candidate's start to last candidate's
+        end).
+        """
+        word = syntax.to_word(field_nodes[0])
+        if len(field_nodes) > 1:
+            word.text = "".join(fn.original for fn in field_nodes)
+            last = field_nodes[-1]
+            if getattr(last, "endchar", None) is not None:
+                word.endchar = last.endchar
+        return word
+
     def do_fieldnames(self, parser, group):
         """This filter finds FieldnameNodes in the tree and applies their
         fieldname to the next node.
@@ -396,24 +411,40 @@ class FieldsPlugin(TaggingPlugin):
             # to text
             schema = parser.schema
             newgroup = group.empty_copy()
-            prev_field_node = None
+            # Collect *all* consecutive field nodes that don't name a real
+            # field, not just the most recent one. A single reference here
+            # used to be overwritten by each new rejected candidate, so in a
+            # run like "aa:bb:cc" (neither ``aa`` nor ``bb`` a field) the
+            # earlier candidate's text was silently dropped instead of folded
+            # back in with the rest.
+            prev_field_nodes = []
 
             for node in group:
                 if isinstance(node, fnclass) and node.fieldname not in schema:
-                    prev_field_node = node
+                    prev_field_nodes.append(node)
                     continue
-                elif prev_field_node:
-                    # If prev_field_node is not None, it contains a field node
-                    # that appeared before this node but isn't in the schema,
-                    # so we'll convert it to text here
+                elif prev_field_nodes:
+                    # prev_field_nodes holds one or more field nodes that
+                    # appeared before this node but aren't in the schema, so
+                    # we convert them back to their literal text here.
+                    original = "".join(fn.original for fn in prev_field_nodes)
                     if node.has_text:
-                        node.text = prev_field_node.original + node.text
+                        node.text = original + node.text
+                        # Widen the surviving node's span back to the first
+                        # folded candidate's start so endchar - startchar
+                        # keeps matching len(text).
+                        first = prev_field_nodes[0]
+                        if (
+                            getattr(first, "startchar", None) is not None
+                            and getattr(node, "startchar", None) is not None
+                        ):
+                            node.startchar = first.startchar
                     else:
-                        newgroup.append(syntax.to_word(prev_field_node))
-                    prev_field_node = None
+                        newgroup.append(self._merge_field_nodes(prev_field_nodes))
+                    prev_field_nodes = []
                 newgroup.append(node)
-            if prev_field_node:
-                newgroup.append(syntax.to_word(prev_field_node))
+            if prev_field_nodes:
+                newgroup.append(self._merge_field_nodes(prev_field_nodes))
             group = newgroup
 
         newgroup = group.empty_copy()

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1000,6 +1000,39 @@ def test_fieldname_fieldname():
     assert q == query.Term("a", "b:")
 
 
+def test_consecutive_unknown_fieldnames():
+    # Regression: a run of two or more consecutive "word:" candidates that
+    # don't name a real field must keep *all* of their text. The demotion
+    # filter used to track only the most recent candidate, so in "aa:bb:cc"
+    # the first ("aa:") was silently dropped and the query became just
+    # bb:cc. Surfaced by stumpylog/whoosh-compat's differential suite
+    # (entry 57).
+    schema = fields.Schema(title=fields.TEXT, content=fields.TEXT)
+    qp = default.QueryParser("content", schema)
+
+    q = qp.parse("aa:bb:cc")
+    assert q == query.And(
+        [
+            query.Term("content", "aa"),
+            query.Term("content", "bb"),
+            query.Term("content", "cc"),
+        ]
+    )
+
+    # A recognized field name in the run stops it on both sides.
+    assert qp.parse("zzz:title:cd") == query.And(
+        [query.Term("content", "zzz"), query.Term("title", "cd")]
+    )
+
+    # Companion span bug: the surviving node's span must cover exactly its
+    # own (merged) text.
+    p = default.QueryParser("content", schema)
+    ns = p.process("aa:bb:cc")
+    word = ns[0]
+    assert word.text == "aa:bb:cc"
+    assert word.endchar - word.startchar == len(word.text)
+
+
 def test_paren_fieldname():
     schema = fields.Schema(kind=fields.ID, content=fields.TEXT)
 


### PR DESCRIPTION
## Problem

`FieldsPlugin.do_fieldnames` demotes `word:` runs that don't name a real field back to literal text, folding each rejected candidate's text onto the token that follows. It tracked only a **single** `prev_field_node` reference, so when two rejected candidates were consecutive the first was overwritten and lost:

```python
# schema has no field 'aa' or 'bb'
>>> qp.parse('aa:bb:cc')   # BEFORE
And([Term('content', 'bb'), Term('content', 'cc')])   # 'aa' silently gone
```

There is no reading under which the user's `aa:` was ever consulted — it just vanished.

A companion **span bug** shares the same merge code: after a demoted candidate's text was prepended to the surviving node, that node's `startchar` still pointed at its own original position, so `endchar - startchar` no longer matched `len(text)`.

## Fix

Accumulate **all** consecutive rejected candidates' `.original` text, in order, before folding it onto the next term (or emitting it as a standalone word when nothing fieldable follows). Widen the surviving node's `startchar` to the first folded candidate's start so its span always covers its own text.

```python
>>> qp.parse('aa:bb:cc')   # AFTER
And([Term('content', 'aa'), Term('content', 'bb'), Term('content', 'cc')])
```

A recognized field name anywhere in the run still stops it on both sides (`zzz:title:cd` → `content:zzz AND title:cd`), unchanged.

## Tests

New `test_consecutive_unknown_fieldnames` in `tests/test_parsing.py` (covers both the dropped-text and span bugs); full suite green (890 passed, 3 skipped).

## Credit

Surfaced by the differential test suite of [`stumpylog/whoosh-compat`](https://github.com/stumpylog/whoosh-compat) (`DIVERGENCES.md`, entry 57).