### PR TITLE
fix: reject dangling date separators instead of silently widening (entry 54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+## [3.49.4] - 2026-09-01
+
+### Fixed
+- A truncated date value with a dangling separator no longer silently widens
+  into a whole month or year. Two independent code paths shared the defect.
+  In the `DateParserPlugin` grammar, the progressive numeric sequence advanced
+  its reported end position past a separator *before* the element after it was
+  tried, and still reported having consumed that separator when the element
+  failed — so `2005-01-` parsed as all of January 2005 and `2005-01-01T` as
+  that whole day, with the leftover fragment ANDed onto the query as stray
+  terms. A non-whitespace separator is now consumed only provisionally, so a
+  dangling `-`/`.`/`:`/`/`/`T` makes `ToEnd` reject the fragment instead.
+  Separately, `DATETIME._parse_datestring` stripped `-`, `.` and spaces
+  unconditionally, so `date:2005-01-` collapsed to `200501` and matched all of
+  January 2005 even with no date plugin installed; a leading or trailing
+  separator is now rejected as an unparseable date. Well-formed values —
+  including natural truncations without a dangling separator (`2005-01`,
+  `2005`) and the bare-digit form (`20050101`) — are unaffected. Surfaced by
+  the differential test suite of
+  [`stumpylog/whoosh-compat`](https://github.com/stumpylog/whoosh-compat)
+  (`DIVERGENCES.md`, entry 54).
+
 ## [3.49.3] - 2026-09-01
 
 ### Fixed

--- a/demo/index.html
+++ b/demo/index.html
@@ -32,7 +32,7 @@
   "url": "https://priya-sundaram-dev.github.io/whoosh/",
   "downloadUrl": "https://pypi.org/project/whoosh3/",
   "codeRepository": "https://github.com/priya-sundaram-dev/whoosh",
-  "softwareVersion": "3.49.3",
+  "softwareVersion": "3.49.4",
   "license": "https://github.com/priya-sundaram-dev/whoosh/blob/main/LICENSE.txt",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
   "keywords": "full-text search, pure python search, BM25, indexing, information retrieval, whoosh, Flask search, Django search, SQLite FTS alternative",

--- a/demo/is-whoosh-still-maintained.html
+++ b/demo/is-whoosh-still-maintained.html
@@ -148,7 +148,7 @@
       existing on-disk indexes keep working;</li>
     <li>ships tagged releases to PyPI with a
       <a href="https://github.com/priya-sundaram-dev/whoosh/blob/main/CHANGELOG.md">changelog</a>
-      &mdash; the latest is <strong>whoosh3&nbsp;3.49.3</strong> (September&nbsp;2026),
+      &mdash; the latest is <strong>whoosh3&nbsp;3.49.4</strong> (September&nbsp;2026),
       one of a steady run of bug-fix and feature releases shipped this month;</li>
     <li>has a public issue tracker with labeled
       <a href="https://github.com/priya-sundaram-dev/whoosh/issues">good-first-issues</a>

--- a/src/whoosh/__init__.py
+++ b/src/whoosh/__init__.py
@@ -25,7 +25,7 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
-__version__: tuple[int, ...] = (3, 49, 3)
+__version__: tuple[int, ...] = (3, 49, 4)
 #: String form of :data:`__version__`, kept in sync automatically so the two
 #: can never drift. Used as the single source of truth for the packaged version
 #: (see ``pyproject.toml``'s ``version = { attr = "whoosh.__version_str__" }``).

--- a/src/whoosh/fields.py
+++ b/src/whoosh/fields.py
@@ -981,6 +981,14 @@ class DATETIME(NUMERIC):
         # YYYY[MM[DD[hh[mm[ss[uuuuuu]]]]]]
         from whoosh.util.times import adatetime, fix, is_void
 
+        # A leading or trailing separator means the value is truncated or
+        # malformed (e.g. "2005-01-"). Stripping separators unconditionally
+        # would make "2005-01-" collapse to "200501" and silently widen into
+        # all of January 2005, with no error — a wrong, non-empty result for
+        # input the user clearly didn't finish typing. Reject it instead.
+        if qstring and (qstring[0] in " -." or qstring[-1] in " -."):
+            raise Exception(f"{qstring!r} is not a parseable date")
+
         qstring = qstring.replace(" ", "").replace("-", "").replace(".", "")
         year = month = day = hour = minute = second = microsecond = None
         if len(qstring) >= 4:

--- a/src/whoosh/qparser/dateparse.py
+++ b/src/whoosh/qparser/dateparse.py
@@ -146,10 +146,17 @@ class Sequence(MultiBase):
         )
         for e in self.elements:
             print_debug(debug, "Seq %s text=%r", self.name, text[pos:])
+            # Position before this iteration's separator, and whether that
+            # separator was non-whitespace. Used to avoid reporting a dangling
+            # separator as consumed when the element after it fails to match.
+            presep_pos = pos
+            sep_was_nonspace = False
             if self.sep_expr and not first:
                 print_debug(debug, "Seq %s looking for sep", self.name)
                 m = self.sep_expr.match(text, pos)
                 if m:
+                    if m.group().strip():
+                        sep_was_nonspace = True
                     pos = m.end()
                 else:
                     print_debug(debug, "Seq %s didn't find sep", self.name)
@@ -165,6 +172,14 @@ class Sequence(MultiBase):
 
             print_debug(debug, "Seq %s result=%r", self.name, at)
             if not at:
+                # The element after the separator didn't match. A non-whitespace
+                # separator (e.g. the trailing "-" in "2005-01-") must not be
+                # reported as part of this sequence's match, or a truncated value
+                # silently widens into a whole month/year. Roll the reported
+                # position back to before that separator so ToEnd rejects the
+                # dangling fragment and the value diagnoses a bad date.
+                if sep_was_nonspace:
+                    pos = presep_pos
                 break
             pos = newpos
 

--- a/tests/test_dateparse.py
+++ b/tests/test_dateparse.py
@@ -648,3 +648,37 @@ def test_161_range_semantics_unchanged_for_base_parser():
     # start floored to the day, end ceiled to the day
     assert q.startdate == datetime(2020, 6, 15, 0, 0, 0, 0, tzinfo=timezone.utc)
     assert q.enddate == datetime(2020, 7, 15, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+
+def test_dangling_separator_does_not_widen():
+    # A truncated value with a dangling (non-whitespace) separator must not
+    # silently widen into a whole month/year. The progressive "simple" grammar
+    # used to report the trailing separator as consumed, so "2005-05-" parsed
+    # as all of May 2005 and "2005-05-10T" as that whole day. ToEnd now rejects
+    # the dangling fragment (whoosh bug surfaced by stumpylog/whoosh-compat,
+    # DIVERGENCES entry 54).
+    assert english.date_from("2005-05-", basedate) is None
+    assert english.date_from("2005-", basedate) is None
+    assert english.date_from("2005-05-10T", basedate) is None
+    assert english.date_from("2005-05-10.", basedate) is None
+
+    # Genuinely truncated-but-well-formed values (no dangling separator) still
+    # parse to their natural span, and full values are unaffected.
+    assert_unamb_span(
+        english.date_from("2005-05-10", basedate),
+        dict(year=2005, month=5, day=10),
+        dict(year=2005, month=5, day=10),
+    )
+    assert_unamb_span(
+        english.date_from("2005-05", basedate),
+        dict(year=2005, month=5),
+        dict(year=2005, month=5),
+    )
+    assert_unamb_span(
+        english.date_from("2005", basedate),
+        dict(year=2005),
+        dict(year=2005),
+    )
+    # A clean word boundary after a complete date still leaves the trailing
+    # token alone rather than being swallowed.
+    assert english.date_from("2005-05-10 xyzzy", basedate) is None

--- a/tests/test_dateparse.py
+++ b/tests/test_dateparse.py
@@ -666,18 +666,18 @@ def test_dangling_separator_does_not_widen():
     # parse to their natural span, and full values are unaffected.
     assert_unamb_span(
         english.date_from("2005-05-10", basedate),
-        dict(year=2005, month=5, day=10),
-        dict(year=2005, month=5, day=10),
+        {"year": 2005, "month": 5, "day": 10},
+        {"year": 2005, "month": 5, "day": 10},
     )
     assert_unamb_span(
         english.date_from("2005-05", basedate),
-        dict(year=2005, month=5),
-        dict(year=2005, month=5),
+        {"year": 2005, "month": 5},
+        {"year": 2005, "month": 5},
     )
     assert_unamb_span(
         english.date_from("2005", basedate),
-        dict(year=2005),
-        dict(year=2005),
+        {"year": 2005},
+        {"year": 2005},
     )
     # A clean word boundary after a complete date still leaves the trailing
     # token alone rather than being swallowed.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -417,6 +417,32 @@ def test_datetime():
         assert q.end == times.datetime_to_long(enddt)
 
 
+def test_datetime_dangling_separator_not_widened():
+    # DATETIME._parse_datestring stripped separators unconditionally, so a
+    # truncated value with a dangling separator collapsed onto a shorter,
+    # whole one: "2010-05-" became all of May 2010, "2010-" all of 2010 --
+    # a wrong, non-empty result for input the user clearly didn't finish.
+    # It now rejects such values instead (whoosh bug surfaced by
+    # stumpylog/whoosh-compat, DIVERGENCES entry 54).
+    dtf = fields.DATETIME()
+
+    for bad in ("2010-05-", "2010-", "2010.05.", "-2010", " 2010", "2010 "):
+        with pytest.raises(Exception):
+            dtf._parse_datestring(bad)
+
+    # Well-formed values (including natural truncations without a dangling
+    # separator, and the bare-digit canonical form) still parse.
+    for good in ("2010-05-23", "2010-05", "2010", "20100523", "2010.05.23"):
+        assert dtf._parse_datestring(good) is not None
+
+    # Through the query parser, a dangling-separator value yields an error
+    # query (matching nothing) rather than a silently-widened range.
+    schema = fields.Schema(id=fields.ID(stored=True), date=dtf)
+    qp = qparser.QueryParser("id", schema)
+    assert not isinstance(qp.parse("date:2010-05-"), query.NumericRange)
+    assert qp.parse("date:2010-05").__class__ is query.NumericRange
+
+
 def test_boolean():
     schema = fields.Schema(id=fields.ID(stored=True), done=fields.BOOLEAN(stored=True))
     ix = RamStorage().create_index(schema)


### PR DESCRIPTION
## Summary

A truncated date value with a **dangling separator** (e.g. `date:2005-01-`) silently widened into a whole month or year, returning a wrong, non-empty result for input the user clearly hadn't finished typing. Two *independent* code paths shared the defect:

1. **`DateParserPlugin` grammar** (`qparser/dateparse.py`, `Sequence.parse`): the progressive numeric sequence advanced its reported end position past a separator **before** trying the element after it, and still reported having consumed that separator when the element failed. So `2005-01-` parsed as *all of January 2005*, `2005-01-01T` as that whole day, and the leftover fragment was ANDed onto the query as stray terms. A non-whitespace separator is now consumed **only provisionally**, so a dangling `-`/`.`/`:`/`/`/`T` makes `ToEnd` reject the fragment.

2. **`DATETIME._parse_datestring`** (`fields.py`): stripped `-`, `.` and spaces unconditionally, so `date:2005-01-` collapsed to `200501` and matched all of January 2005 **even with no date plugin installed**. A leading or trailing separator is now rejected as an unparseable date (yielding an error query, consistent with how the field already handles other bad dates).

## Not affected
Well-formed values still parse exactly as before, including natural truncations that carry **no** dangling separator (`2005-01`, `2005`), the bare-digit canonical form (`20050101`), and ordinary ranges.

## Tests
`test_dangling_separator_does_not_widen` (grammar) and `test_datetime_dangling_separator_not_widened` (field + query-parser). Full suite: **893 passed, 3 skipped**.

## Credit
Surfaced by the differential test suite of [`stumpylog/whoosh-compat`](https://github.com/stumpylog/whoosh-compat) (`DIVERGENCES.md`, entry 54), which documents the same defect against a pinned oracle and fixes it on its own fork.