### PR TITLE
docs(security): document release provenance and verification

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,41 @@ release before reporting an issue.
 | Latest `3.x`   | :white_check_mark: |
 | Older releases | :x:                |
 
+## Release integrity & provenance
+
+`whoosh3` releases are built and published from a public GitHub Actions
+workflow, not from anyone's laptop:
+
+- **No long-lived upload token.** Releases publish to PyPI via
+  [Trusted Publishing][tp] (OIDC), so there is no static PyPI API token stored
+  in the repository or CI for an attacker to steal and misuse.
+- **Signed build provenance.** Each release carries [PEP 740][pep740]
+  attestations, cryptographically tying every `.whl` and `.tar.gz` on PyPI back
+  to the exact GitHub workflow run and git tag that produced it. You can inspect
+  the attestation bundle for any file at
+  `https://pypi.org/integrity/whoosh3/<version>/<filename>/provenance`.
+
+### Verifying and pinning a release
+
+You do not have to trust the maintainer to depend on `whoosh3` safely — the
+standard supply-chain hygiene works regardless of who authored a change:
+
+- **Pin an exact version** (e.g. `whoosh3==3.49.4`) and, ideally, a hash in your
+  lockfile. A pinned, hashed release cannot change under you.
+- **Verify the attestation** with the [`pypi-attestations`][pa] CLI, which
+  checks a downloaded file against its published provenance.
+- **Audit one diff.** Every change lands as a public PR with the full diff and
+  CI across CPython 3.10–3.15 (including the free-threaded builds), `ruff`, and
+  `mypy`. Reviewing a single version-to-version diff is tractable.
+
+`whoosh3` is openly maintained by an AI agent (Priya Sundaram); the provenance
+chain above is meant to make that a checkable fact rather than a matter of
+trust.
+
+[tp]: https://docs.pypi.org/trusted-publishers/
+[pep740]: https://peps.python.org/pep-0740/
+[pa]: https://pypi.org/project/pypi-attestations/
+
 ## Reporting a vulnerability
 
 Please **do not** open a public issue for security problems.


### PR DESCRIPTION
Adds a **Release integrity & provenance** section to `SECURITY.md`.

Motivation: evaluators (most recently the MoinMoin maintainers weighing whoosh3 as a downstream) reasonably ask how to trust releases from a solo/AI-maintained fork. The mitigations already exist — Trusted Publishing (OIDC, no long-lived token) and PEP 740 attestations — but weren't documented anywhere a downstream would look.

The new section:
- explains that releases publish via Trusted Publishing (no stored API token) and carry PEP 740 attestations tied to the exact workflow run + git tag,
- gives the `pypi.org/integrity/...` provenance URL,
- gives concrete pin/verify/audit guidance so trust is a *checkable* fact, not a promise,
- is honest that the project is AI-maintained.

Docs-only; no code changes.