### PR TITLE
fix(query): keep bracket character classes before a trailing star (paperless-ngx #13568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+## [3.49.5] - 2026-09-02
+
+### Fixed
+- A trailing-star wildcard whose prefix contains a `[` character class no
+  longer folds to a `Prefix` query, which silently dropped the class body.
+  `[` is one of `Wildcard.SPECIAL_CHARS` (`"*?["`), but both fold sites —
+  `Wildcard.normalize()` (`whoosh/query/terms.py`) and
+  `WildcardPlugin.do_wildcards` (`whoosh/qparser/plugins.py`) — only tested
+  for `*`/`?` before rewriting `text*` to `Prefix(text)`. A pattern like
+  `202[0-3]*` therefore collapsed to the literal prefix `202[0-3]`, matching
+  nothing instead of `2020`–`2023`. Both sites now keep such a pattern a
+  `Wildcard`; a plain trailing star with no class (`abc*`) still folds to a
+  `Prefix` as before. Mirrors paperless-ngx issue
+  [#13568](https://github.com/paperless-ngx/paperless-ngx/issues/13568) and
+  the differential test suite of
+  [`stumpylog/whoosh-compat`](https://github.com/stumpylog/whoosh-compat)
+  (`DIVERGENCES.md`, entry 13).
+
 ## [3.49.4] - 2026-09-01
 
 ### Fixed

--- a/demo/index.html
+++ b/demo/index.html
@@ -32,7 +32,7 @@
   "url": "https://priya-sundaram-dev.github.io/whoosh/",
   "downloadUrl": "https://pypi.org/project/whoosh3/",
   "codeRepository": "https://github.com/priya-sundaram-dev/whoosh",
-  "softwareVersion": "3.49.4",
+  "softwareVersion": "3.49.5",
   "license": "https://github.com/priya-sundaram-dev/whoosh/blob/main/LICENSE.txt",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
   "keywords": "full-text search, pure python search, BM25, indexing, information retrieval, whoosh, Flask search, Django search, SQLite FTS alternative",

--- a/demo/is-whoosh-still-maintained.html
+++ b/demo/is-whoosh-still-maintained.html
@@ -148,7 +148,7 @@
       existing on-disk indexes keep working;</li>
     <li>ships tagged releases to PyPI with a
       <a href="https://github.com/priya-sundaram-dev/whoosh/blob/main/CHANGELOG.md">changelog</a>
-      &mdash; the latest is <strong>whoosh3&nbsp;3.49.4</strong> (September&nbsp;2026),
+      &mdash; the latest is <strong>whoosh3&nbsp;3.49.5</strong> (September&nbsp;2026),
       one of a steady run of bug-fix and feature releases shipped this month;</li>
     <li>has a public issue tracker with labeled
       <a href="https://github.com/priya-sundaram-dev/whoosh/issues">good-first-issues</a>

--- a/src/whoosh/__init__.py
+++ b/src/whoosh/__init__.py
@@ -25,7 +25,7 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
-__version__: tuple[int, ...] = (3, 49, 4)
+__version__: tuple[int, ...] = (3, 49, 5)
 #: String form of :data:`__version__`, kept in sync automatically so the two
 #: can never drift. Used as the single source of truth for the packaged version
 #: (see ``pyproject.toml``'s ``version = { attr = "whoosh.__version_str__" }``).

--- a/src/whoosh/qparser/plugins.py
+++ b/src/whoosh/qparser/plugins.py
@@ -173,7 +173,11 @@ class WildcardPlugin(TaggingPlugin):
             node = group[i]
             if isinstance(node, self.WildcardNode):
                 text = node.text
-                if len(text) > 1 and not any(qm in text for qm in self.qmarks):
+                if (
+                    len(text) > 1
+                    and "[" not in text
+                    and not any(qm in text for qm in self.qmarks)
+                ):
                     if text.find("*") == len(text) - 1:
                         newnode = PrefixPlugin.PrefixNode(text[:-1])
                         newnode.startchar = node.startchar

--- a/src/whoosh/query/terms.py
+++ b/src/whoosh/query/terms.py
@@ -392,9 +392,16 @@ class Wildcard(PatternQuery):
         if "*" not in text and "?" not in text:
             # If no wildcard chars, convert to a normal term.
             return Term(self.fieldname, self.text, boost=self.boost)
-        elif "?" not in text and text.endswith("*") and text.find("*") == len(text) - 1:
+        elif (
+            "?" not in text
+            and "[" not in text
+            and text.endswith("*")
+            and text.find("*") == len(text) - 1
+        ):
             # If the only wildcard char is an asterisk at the end, convert to a
-            # Prefix query.
+            # Prefix query. A "[" would begin a character class (it is in
+            # SPECIAL_CHARS), so a pattern like "202[0-3]*" must stay a Wildcard
+            # rather than fold to the literal prefix "202[0-3]".
             return Prefix(self.fieldname, self.text[:-1], boost=self.boost)
         else:
             return self

--- a/tests/test_parse_plugins.py
+++ b/tests/test_parse_plugins.py
@@ -271,6 +271,30 @@ def test_prefix_plugin():
         assert len(r) == 1
 
 
+def test_wildcard_plugin_keeps_bracket_class_before_trailing_star():
+    # gh: WildcardPlugin.do_wildcards folded any trailing-star pattern to a
+    # PrefixNode after only checking for "?" -- so "202[0-3]*" collapsed to the
+    # literal prefix "202[0-3]", destroying the character class. It must stay a
+    # Wildcard so the class matches.
+    schema = fields.Schema(title=fields.ID(stored=True))
+    ix = RamStorage().create_index(schema)
+    w = ix.writer()
+    for t in ("2019x", "2020x", "2021x", "2023x", "2025x", "202z"):
+        w.add_document(title=t)
+    w.commit()
+
+    with ix.searcher() as s:
+        qp = qparser.QueryParser("title", schema)
+        q = qp.parse("202[0-3]*")
+        assert q.__class__ is query.Wildcard
+        assert q.text == "202[0-3]*"
+        hits = sorted(h["title"] for h in s.search(q, limit=None))
+        assert hits == ["2020x", "2021x", "2023x"]
+
+        # A plain trailing star still folds to a Prefix.
+        assert qp.parse("202*").__class__ is query.Prefix
+
+
 def test_custom_tokens():
     qp = qparser.QueryParser("text", None)
     qp.remove_plugin_class(plugins.OperatorsPlugin)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -237,6 +237,16 @@ def test_merge_ranges():
     assert q.normalize() == Every("f1")
 
 
+def test_wildcard_trailing_star_bracket_class_not_folded():
+    # gh: a trailing-star wildcard whose prefix contains a "[" character class
+    # must NOT fold to a Prefix query -- doing so silently drops the class body.
+    # "[" is one of Wildcard.SPECIAL_CHARS, so "202[0-3]*" stays a Wildcard.
+    q = Wildcard("title", "202[0-3]*")
+    assert q.normalize() == q
+    # A plain trailing star (no class) still folds to a Prefix.
+    assert Wildcard("title", "abc*").normalize() == Prefix("title", "abc")
+
+
 def test_normalize_compound():
     def oq():
         return Or([Term("a", "a"), Term("a", "b")])


### PR DESCRIPTION
## Problem

A trailing-star wildcard whose prefix contains a `[` character class was silently folded to a `Prefix` query, dropping the class body.

```python
>>> from whoosh.query import Wildcard
>>> Wildcard('title', '202[0-3]*').normalize()
Prefix('title', '202[0-3]')   # before: matches nothing
```

`[` is one of `Wildcard.SPECIAL_CHARS` (`"*?["`), but both fold sites — `Wildcard.normalize()` and `WildcardPlugin.do_wildcards` — only tested for `*`/`?` before rewriting `text*` → `Prefix(text)`. So `202[0-3]*` collapsed to the literal prefix `202[0-3]` and matched nothing instead of `2020`–`2023`.

## Fix

Guard the fold on `[` at both sites. A bracket-class pattern now stays a `Wildcard`; a plain trailing star (`abc*`) still folds to a `Prefix`.

## Tests

- `test_wildcard_trailing_star_bracket_class_not_folded` (normalize path)
- `test_wildcard_plugin_keeps_bracket_class_before_trailing_star` (parser + e2e search)

Full query/parser suites pass (132 tests).

Surfaced by the differential suite of [`stumpylog/whoosh-compat`](https://github.com/stumpylog/whoosh-compat) (`DIVERGENCES.md`, entry 13); mirrors paperless-ngx [#13568](https://github.com/paperless-ngx/paperless-ngx/issues/13568).