### PR TITLE
fix(qparser): keep quoted values on atomic self-parsing fields (BOOLEAN/NUMERIC/DATETIME) working (whoosh-compat entry 38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+## [3.49.6] - 2026-09-02
+
+### Fixed
+- A double-quoted value on a self-parsing "atomic" field (`BOOLEAN`,
+  `NUMERIC`, `DATETIME`, …) is now handed to the field's own `parse_query`,
+  exactly like the unquoted and single-quoted forms, instead of being
+  tokenized as free text. Previously `PhrasePlugin` sent the quoted text
+  through the field's analyzer: a `BOOLEAN` field has none, so `flag:"true"`
+  raised a bare `Exception: … field has no analyzer`, and a `NUMERIC` field's
+  identity analyzer produced the raw string term `num:"42"` → `Term("num",
+  "42")` that could never match the encoded numeric value (`num:42` and
+  `num:'42'` both worked). N-gram fields (`NGRAM`/`NGRAMWORDS`) are
+  self-parsing too but genuinely tokenize their input, so they keep producing
+  `Phrase` queries. Mirrors
+  [`stumpylog/whoosh-compat`](https://github.com/stumpylog/whoosh-compat)
+  (`DIVERGENCES.md`, entry 38).
+
 ## [3.49.5] - 2026-09-02
 
 ### Fixed

--- a/demo/index.html
+++ b/demo/index.html
@@ -32,7 +32,7 @@
   "url": "https://priya-sundaram-dev.github.io/whoosh/",
   "downloadUrl": "https://pypi.org/project/whoosh3/",
   "codeRepository": "https://github.com/priya-sundaram-dev/whoosh",
-  "softwareVersion": "3.49.5",
+  "softwareVersion": "3.49.6",
   "license": "https://github.com/priya-sundaram-dev/whoosh/blob/main/LICENSE.txt",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
   "keywords": "full-text search, pure python search, BM25, indexing, information retrieval, whoosh, Flask search, Django search, SQLite FTS alternative",

--- a/demo/is-whoosh-still-maintained.html
+++ b/demo/is-whoosh-still-maintained.html
@@ -148,7 +148,7 @@
       existing on-disk indexes keep working;</li>
     <li>ships tagged releases to PyPI with a
       <a href="https://github.com/priya-sundaram-dev/whoosh/blob/main/CHANGELOG.md">changelog</a>
-      &mdash; the latest is <strong>whoosh3&nbsp;3.49.5</strong> (September&nbsp;2026),
+      &mdash; the latest is <strong>whoosh3&nbsp;3.49.6</strong> (September&nbsp;2026),
       one of a steady run of bug-fix and feature releases shipped this month;</li>
     <li>has a public issue tracker with labeled
       <a href="https://github.com/priya-sundaram-dev/whoosh/issues">good-first-issues</a>

--- a/src/whoosh/__init__.py
+++ b/src/whoosh/__init__.py
@@ -25,7 +25,7 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
-__version__: tuple[int, ...] = (3, 49, 5)
+__version__: tuple[int, ...] = (3, 49, 6)
 #: String form of :data:`__version__`, kept in sync automatically so the two
 #: can never drift. Used as the single source of truth for the packaged version
 #: (see ``pyproject.toml``'s ``version = { attr = "whoosh.__version_str__" }``).

--- a/src/whoosh/qparser/plugins.py
+++ b/src/whoosh/qparser/plugins.py
@@ -705,6 +705,24 @@ class FunctionPlugin(TaggingPlugin):
         return newgroup
 
 
+def _is_atomic_self_parsing(field) -> bool:
+    """Return True for self-parsing fields whose value is a single atomic
+    token (BOOLEAN, NUMERIC, DATETIME, ...), for which a double-quoted value
+    should be handed to ``parse_query`` rather than tokenized as a phrase.
+
+    N-gram fields are self-parsing but genuinely split their input into
+    tokens, so they are excluded: the distinguishing signal is that atomic
+    fields have no analyzer, or an identity (``IDTokenizer``) analyzer that
+    yields the whole string back unchanged.
+    """
+    from whoosh.analysis.tokenizers import IDTokenizer
+
+    if not field.self_parsing():
+        return False
+    analyzer = getattr(field, "analyzer", None)
+    return analyzer is None or isinstance(analyzer, IDTokenizer)
+
+
 class PhrasePlugin(Plugin):
     """Adds the ability to specify phrase queries inside double quotes."""
 
@@ -746,6 +764,21 @@ class PhrasePlugin(Plugin):
             sc = self.textstartchar
             if parser.schema and fieldname in parser.schema:
                 field = parser.schema[fieldname]
+                if _is_atomic_self_parsing(field):
+                    # Atomic self-parsing fields (BOOLEAN, NUMERIC, DATETIME,
+                    # ...) treat the whole value as one token and interpret it
+                    # themselves rather than splitting it into free-text words.
+                    # A double-quoted value is not a meaningful phrase for such
+                    # a field, so route it through ``parse_query`` exactly like
+                    # the unquoted/single-quoted form. Without this, a quoted
+                    # value either crashed (BOOLEAN has no analyzer) or silently
+                    # produced a wrong query (e.g. NUMERIC ``n:"42"`` yielded the
+                    # raw string ``"42"`` instead of the encoded numeric term).
+                    # N-gram fields are self-parsing too but genuinely tokenize
+                    # their input, so they keep the phrase path below.
+                    return attach(
+                        field.parse_query(fieldname, text, boost=self.boost), self
+                    )
                 if field.analyzer:
                     # We have a field with an analyzer, so use it to parse
                     # the phrase into tokens

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1206,9 +1206,7 @@ def test_quoted_value_on_self_parsing_fields():
     # BOOLEAN value crashed ("field has no analyzer") and a quoted NUMERIC
     # value silently produced a raw-string term that could never match.
     # (whoosh-compat DIVERGENCES entry 38.)
-    schema = fields.Schema(
-        text=fields.TEXT, flag=fields.BOOLEAN, num=fields.NUMERIC
-    )
+    schema = fields.Schema(text=fields.TEXT, flag=fields.BOOLEAN, num=fields.NUMERIC)
     qp = default.QueryParser("text", schema)
 
     # BOOLEAN: quoted value no longer raises and coerces to a boolean term,

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1197,3 +1197,45 @@ def test_multitoken_with_factory():
 
     querystring = "get my name/address"
     _ = qp.parse(querystring)
+
+
+def test_quoted_value_on_self_parsing_fields():
+    # A double-quoted value on a self-parsing "atomic" field (BOOLEAN,
+    # NUMERIC, DATETIME) must be handed to the field's own parse_query,
+    # exactly like the unquoted/single-quoted form. Before this fix a quoted
+    # BOOLEAN value crashed ("field has no analyzer") and a quoted NUMERIC
+    # value silently produced a raw-string term that could never match.
+    # (whoosh-compat DIVERGENCES entry 38.)
+    schema = fields.Schema(
+        text=fields.TEXT, flag=fields.BOOLEAN, num=fields.NUMERIC
+    )
+    qp = default.QueryParser("text", schema)
+
+    # BOOLEAN: quoted value no longer raises and coerces to a boolean term,
+    # matching the unquoted form.
+    for qs in ('flag:""', 'flag:"true"', 'flag:"false"', 'flag:"t*"'):
+        q = qp.parse(qs)
+        assert q.__class__ == query.Term
+        assert q.fieldname == "flag"
+        assert isinstance(q.text, bool)
+    assert qp.parse('flag:"true"').text is True
+    assert qp.parse('flag:"false"').text is False
+
+    # NUMERIC: a quoted value encodes to the same term as the unquoted and
+    # single-quoted forms, instead of the raw string "42".
+    quoted = qp.parse('num:"42"')
+    unquoted = qp.parse("num:42")
+    single = qp.parse("num:'42'")
+    assert quoted.__class__ == query.Term
+    assert quoted.text == unquoted.text == single.text
+    assert quoted.text != "42"
+
+
+def test_quoted_value_on_ngram_fields_still_phrases():
+    # N-gram fields are self-parsing too, but genuinely tokenize their input,
+    # so a double-quoted value must keep producing a Phrase (not be routed to
+    # parse_query). Guards against over-broadening the fix above.
+    schema = fields.Schema(g=fields.NGRAM, gw=fields.NGRAMWORDS)
+    qp = default.QueryParser("g", schema)
+    assert qp.parse('g:"web3d"').__class__ == query.Phrase
+    assert qp.parse('gw:"web 3d"').__class__ == query.Phrase


### PR DESCRIPTION
A double-quoted value on a **self-parsing atomic field** — `BOOLEAN`, `NUMERIC`, `DATETIME` — was routed through the field's analyzer by `PhrasePlugin.PhraseNode.query`, which is wrong for these fields:

- **`BOOLEAN`** has no analyzer, so `flag:"true"` raised a bare `Exception: <class 'whoosh.fields.BOOLEAN'> field has no analyzer` at parse time. Every quoted value shape crashed (`flag:""`, `flag:"true"`, `flag:"  false  "`, `flag:"t*"`).
- **`NUMERIC`** uses an identity `IDTokenizer`, so `num:"42"` silently produced `Term("num", "42")` — the raw string, which can never match the encoded numeric term that `num:42` and `num:42` (unquoted / single-quoted) both build correctly.

### Fix
Quoted values on these atomic fields are now handed to the field's own `parse_query`, exactly like the unquoted and single-quoted forms:

```
flag:"true"  -> Term("flag", True)
flag:""      -> Term("flag", False)
num:"42"     -> Term("num", <encoded>)   # == num:42 == num:'42'
```

N-gram fields (`NGRAM`/`NGRAMWORDS`) are self-parsing too but **genuinely tokenize** their input, so they are excluded and keep producing `Phrase` queries (`g:"web3d"` -> `Phrase`). The discriminator is that atomic fields have no analyzer or an identity `IDTokenizer`.

### Tests
- `test_quoted_value_on_self_parsing_fields` — BOOLEAN no longer raises and coerces to bool; NUMERIC quoted term equals the unquoted/single-quoted term and is not the raw string.
- `test_quoted_value_on_ngram_fields_still_phrases` — guards against over-broadening; NGRAM/NGRAMWORDS quoted values stay `Phrase`.

Full suite: 896 passed, 4 skipped.

Mirrors [`stumpylog/whoosh-compat`](https://github.com/stumpylog/whoosh-compat) `DIVERGENCES.md`, entry 38. Credit to the whoosh-compat differential test suite for surfacing this. Ships as **3.49.6**.