### PR TITLE
test(spans): make shared get_index() cache thread-safe

### DIFF
--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -1,3 +1,4 @@
+import threading
 from itertools import permutations
 
 from whoosh import analysis, fields, formats
@@ -7,25 +8,37 @@ from whoosh.util.testing import TempIndex
 
 domain = ("alfa", "bravo", "bravo", "charlie", "delta", "echo")
 _ix = None
+_ix_lock = threading.Lock()
 
 
 def get_index():
+    # The shared index is built lazily and cached. Guard the build with a lock
+    # so that, under free-threaded/parallel test runners, concurrent callers do
+    # not both enter the builder (which previously raced on the segment TOC,
+    # e.g. "File '_MAIN_1.toc' exists") or observe a half-committed index.
     global _ix
 
     if _ix is not None:
         return _ix
 
-    charfield = fields.FieldType(
-        formats.Characters(), analysis.SimpleAnalyzer(), scorable=True, stored=True
-    )
-    schema = fields.Schema(text=charfield)
-    st = RamStorage()
-    _ix = st.create_index(schema)
+    with _ix_lock:
+        if _ix is not None:
+            return _ix
 
-    w = _ix.writer()
-    for ls in permutations(domain, 4):
-        w.add_document(text=" ".join(ls), _stored_text=ls)
-    w.commit()
+        charfield = fields.FieldType(
+            formats.Characters(), analysis.SimpleAnalyzer(), scorable=True, stored=True
+        )
+        schema = fields.Schema(text=charfield)
+        st = RamStorage()
+        ix = st.create_index(schema)
+
+        w = ix.writer()
+        for ls in permutations(domain, 4):
+            w.add_document(text=" ".join(ls), _stored_text=ls)
+        w.commit()
+
+        # Publish only after the index is fully built and committed.
+        _ix = ix
 
     return _ix
 


### PR DESCRIPTION
## What

The module-level lazy `_ix` cache in `tests/test_spans.py` used an unlocked check-then-build pattern:

```python
if _ix is not None:
    return _ix
# ... build index, writer, commit ...
_ix = ...
```

## Why

Under the free-threading / `--parallel-threads=auto` race detector job, concurrent callers of `get_index()` could both see `_ix is None` and enter the builder simultaneously (or one thread could observe a half-committed index published mid-build). This raced on the segment TOC and failed intermittently with:

```
NameError: File '_MAIN_1.toc' exists
```

This surfaced as a flaky failure of the **Free-threading race check (Python 3.14t)** CI job (e.g. run on `e0160f1`), passing on retry — exactly the kind of latent race that job exists to catch.

## Fix

Guard the build with a `threading.Lock` using double-checked locking, and only publish `_ix` **after** the index is fully built and committed, so no thread ever observes a partially-built index.

Test-only change; no library behavior is affected. `tests/test_spans.py` passes (23 passed) and ruff is clean.