### PR TITLE
typing(idsets): clear the last single-instance ty rule (invalid-ignore-comment) (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Changed
+
+- Typing: `DocIdSet.__eq__` now narrows its `object` argument to an
+  `Iterable` (returning `NotImplemented` for non-iterables, the correct
+  `__eq__` contract) instead of carrying a malformed
+  `# type: ignore[call-overload]` comment. Clears the last single-instance
+  `ty` rule (`invalid-ignore-comment`), which is dropped from the `[tool.ty]`
+  ignore list (gh#144, part of gh#121). Comparing an id set with a
+  non-iterable now returns `False` rather than raising `TypeError`.
+
 ## [3.49.6] - 2026-09-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,13 +184,12 @@ warn_unused_ignores = true
 # TODO: Gradual typing: Revisit these ignores and remove them as the codebase is
 # incrementally typed (gh#121).  Instance counts are a dated snapshot (ty 0.0.74,
 # 2026-08-24) to help contributors pick a tractable rule to clear next -- the
-# single-instance ones (empty-body, invalid-ignore-comment,
-# parameter-already-assigned) are the smallest starting points.  Re-run
+# single-instance ones (empty-body, parameter-already-assigned) are the
+# smallest starting points (invalid-ignore-comment was cleared in gh#144).  Re-run
 # `ty check src/whoosh` with a rule flipped to "warn" to get a fresh count.
 rules.call-non-callable = "ignore"  # 20 instances
 rules.invalid-argument-type = "ignore"  # 30 instances
 rules.invalid-assignment = "ignore"  # 21 instances
-rules.invalid-ignore-comment = "ignore"  # 1 instance
 rules.invalid-method-override = "ignore"  # 131 instances
 rules.missing-argument = "ignore"  # 12 instances
 rules.not-subscriptable = "ignore"  # 15 instances

--- a/src/whoosh/idsets.py
+++ b/src/whoosh/idsets.py
@@ -297,10 +297,14 @@ class DocIdSet:
     """
 
     def __eq__(self, other: object) -> bool:
-        # Equality is defined element-wise against any iterable of ints; the
-        # ``# type: ignore`` covers the intentionally broad ``object`` param
-        # required to override ``object.__eq__``.
-        for a, b in zip(self, other):  # type: ignore[call-overload]
+        # Equality is defined element-wise against any iterable of ints.
+        # ``other`` is typed ``object`` to satisfy the ``object.__eq__``
+        # override contract; narrow it to an iterable here rather than
+        # suppress the checker. Anything non-iterable is not comparable, so
+        # defer to the runtime (``NotImplemented`` -> identity fallback).
+        if not isinstance(other, Iterable):
+            return NotImplemented
+        for a, b in zip(self, other):
             if a != b:
                 return False
         return True


### PR DESCRIPTION
Fixes #144 (part of the gradual-typing effort tracked in #121).

## Problem
`DocIdSet.__eq__` carried a malformed suppression comment:

```
error[invalid-ignore-comment]: Invalid `type: ignore` comment: no whitespace after `ignore`
   --> src/whoosh/idsets.py:298:27
```

The `# type: ignore[call-overload]` was there because `other` is typed `object` (as `object.__eq__` overrides require), which checkers don't consider iterable, so `zip(self, other)` complained.

## Fix
Narrow `other` with `isinstance(other, Iterable)` and return `NotImplemented` for non-iterables — the correct `__eq__` contract — rather than swap one ignore for another. `Iterable` was already imported. Then drop `rules.invalid-ignore-comment` from `[tool.ty]`: it was the **last single-instance** rule on the ignore list.

Minor behaviour improvement: comparing an id set with a non-iterable now returns `False` (via `NotImplemented` identity fallback) instead of raising `TypeError`.

## Verification
- `ty check src/whoosh` → All checks passed (with the rule removed)
- `mypy src/whoosh/idsets.py` → Success
- `ruff check` / `ruff format --check` → clean
- `pytest tests/test_bits.py` → 13 passed

CHANGELOG updated under [Unreleased].