### PR TITLE
fix(dateparse): resolve [time TO concrete-instant] ranges instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- Date-range queries whose lower bound is a bare time of day and whose upper
+  bound resolves straight to a concrete instant — for example
+  `added:[noon TO now]` or `added:[noon TO -1 week]` — no longer crash the
+  parser with `AttributeError: 'datetime.datetime' object has no attribute
+  'ceil'`. The range-disambiguation step compared `start.floor().time()` with
+  `end.ceil().time()` by calling the `adatetime` methods directly, but a bound
+  that resolves to a plain `datetime` (like `now` or a relative offset) has no
+  such methods. Both sides now go through the module-level `floor()`/`ceil()`
+  helpers, which pass a concrete `datetime` through unchanged, so these
+  ordinary "time-of-day until a fixed instant" ranges resolve correctly.
+
 ### Changed
 
 - Typing: `DocIdSet.__eq__` now narrows its `object` argument to an

--- a/src/whoosh/util/times.py
+++ b/src/whoosh/util/times.py
@@ -397,7 +397,14 @@ class timespan:
             start_dm = not (start.month is None and start.day is None)
             end_dm = not (end.month is None and end.day is None)
             if end_dm and not start_dm:
-                if start.floor().time() > end.ceil().time():
+                # ``start``/``end`` may already be concrete ``datetime`` objects
+                # here (for example when a bound resolves straight to an instant,
+                # such as ``now`` or a ``-1 week`` offset). Plain ``datetime`` has
+                # no ``floor``/``ceil`` methods, so route both sides through the
+                # module-level helpers, which pass a concrete ``datetime`` through
+                # unchanged. Calling ``start.floor()``/``end.ceil()`` directly
+                # raised ``AttributeError`` on such ranges (e.g. ``[noon TO now]``).
+                if floor(start).time() > ceil(end).time():
                     start.month = basedate.month
                     start.day = basedate.day
                 else:

--- a/tests/test_dateparse.py
+++ b/tests/test_dateparse.py
@@ -682,3 +682,25 @@ def test_dangling_separator_does_not_widen():
     # A clean word boundary after a complete date still leaves the trailing
     # token alone rather than being swallowed.
     assert english.date_from("2005-05-10 xyzzy", basedate) is None
+
+
+def test_time_lower_bound_to_concrete_instant_upper():
+    # gh: a range whose start is a bare time of day and whose end resolves
+    # straight to a concrete instant (``now``, or a relative offset such as
+    # ``-1 week``) used to crash the parser with
+    # ``AttributeError: 'datetime.datetime' object has no attribute 'ceil'``.
+    # The disambiguation compared ``start.floor().time()`` with
+    # ``end.ceil().time()`` by calling the ``adatetime`` methods directly, but
+    # the concrete side is a plain ``datetime``. Routing both sides through the
+    # module-level ``floor()``/``ceil()`` helpers passes concrete datetimes
+    # through unchanged, so these ordinary ranges resolve instead of crashing.
+    ts = english.date_from("noon to now", basedate)
+    assert ts.__class__ is timespan
+    # noon today (12:00) through the basedate instant (15:16:06.454).
+    assert ts.start == datetime(2010, 9, 20, 12, 0, 0, 0, tzinfo=timezone.utc)
+    assert ts.end == basedate
+
+    # A relative offset upper bound (also a concrete datetime) works too.
+    ts2 = english.date_from("noon to -1 week", basedate)
+    assert ts2.__class__ is timespan
+    assert ts2.end == basedate - timedelta(weeks=1)


### PR DESCRIPTION
## Problem

A date range whose start is a bare **time of day** and whose end resolves straight to a **concrete instant** crashed the query parser:

```python
qp.parse("added:[noon TO now]")
# AttributeError: 'datetime.datetime' object has no attribute 'ceil'
```

This reproduces for any upper bound that resolves to a plain `datetime`, e.g. `now` or a relative offset like `-1 week`. These are perfectly ordinary, answerable ranges ("noon today until now").

## Cause

In `timespan.disambiguated` (`whoosh/util/times.py`), when the end has a month+day but the start does not, the code decided whether copying the end date would invert the range by comparing:

```python
if start.floor().time() > end.ceil().time():
```

`floor()`/`ceil()` are `adatetime` methods — they only exist while a bound is still ambiguous. A bound that resolves to a concrete `datetime` has neither, so `end.ceil()` raises `AttributeError` out of the parser.

## Fix

Route both sides through the module-level `floor()`/`ceil()` helpers, which already pass a concrete `datetime` through unchanged and call the method otherwise:

```python
if floor(start).time() > ceil(end).time():
```

Now `added:[noon TO now]` resolves to noon-today through the `now` instant, as expected. Adds a regression test covering both the `now` and relative-offset (`-1 week`) upper-bound forms.

No runtime behaviour changes for ranges that already worked.