### PR TITLE
feat(typing): add type annotations to whoosh.util.text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Changed
+
+- Typing: added parameter and return annotations to all public functions in
+  `whoosh.util.text` (`byte`, `first_diff`, `prefix_encode`,
+  `prefix_encode_all`, `prefix_decode_all`, `natural_key`, `rcompile`)
+  (gh#173, part of gh#121).
+
 ## [3.49.7] - 2026-09-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ All notable changes to this project are documented here. This project follows
 - Typing: added parameter and return annotations to all public functions in
   `whoosh.util.text` (`byte`, `first_diff`, `prefix_encode`,
   `prefix_encode_all`, `prefix_decode_all`, `natural_key`, `rcompile`)
-  (gh#173, part of gh#121).
+  (gh#173, part of gh#121). `rcompile` now declares `re.Pattern[str]`, which
+  let the checker flag and fix the downstream `expression` parameters in
+  `whoosh.analysis.analyzers` (now `str | re.Pattern[str]`, matching the
+  tokenizers) and the `text`/`pos` parameters of the `whoosh.qparser.dateparse`
+  parser classes.
 
 ## [3.49.7] - 2026-09-03
 

--- a/src/whoosh/analysis/analyzers.py
+++ b/src/whoosh/analysis/analyzers.py
@@ -27,6 +27,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -170,7 +171,9 @@ def RegexAnalyzer(expression: str = r"\w+(\.?\w+)*", gaps: bool = False) -> Comp
     return RegexTokenizer(expression=expression, gaps=gaps)
 
 
-def SimpleAnalyzer(expression: str = default_pattern, gaps: bool = False) -> Analyzer:
+def SimpleAnalyzer(
+    expression: str | re.Pattern[str] = default_pattern, gaps: bool = False
+) -> Analyzer:
     """Composes a RegexTokenizer with a LowercaseFilter.
 
     >>> ana = SimpleAnalyzer()
@@ -186,7 +189,7 @@ def SimpleAnalyzer(expression: str = default_pattern, gaps: bool = False) -> Ana
 
 
 def StandardAnalyzer(
-    expression: str = default_pattern,
+    expression: str | re.Pattern[str] = default_pattern,
     stoplist: Collection[str] | None = STOP_WORDS,
     minsize: int = 2,
     maxsize: int | None = None,
@@ -216,7 +219,7 @@ def StandardAnalyzer(
 
 
 def StemmingAnalyzer(
-    expression: str = default_pattern,
+    expression: str | re.Pattern[str] = default_pattern,
     stoplist: Collection[str] | None = STOP_WORDS,
     minsize: int = 2,
     maxsize: int | None = None,
@@ -253,7 +256,7 @@ def StemmingAnalyzer(
 
 
 def CJKAnalyzer(
-    expression: str = default_pattern,
+    expression: str | re.Pattern[str] = default_pattern,
     stoplist: Collection[str] | None = STOP_WORDS,
     gaps: bool = False,
 ) -> Analyzer:
@@ -332,7 +335,7 @@ def FancyAnalyzer(
 
 def LanguageAnalyzer(
     lang: str,
-    expression: str = default_pattern,
+    expression: str | re.Pattern[str] = default_pattern,
     gaps: bool = False,
     cachesize: int | None = 50000,
 ) -> Analyzer:

--- a/src/whoosh/qparser/dateparse.py
+++ b/src/whoosh/qparser/dateparse.py
@@ -84,7 +84,7 @@ class ParserBase:
         else:
             return e
 
-    def parse(self, text, dt, pos=0, debug=-9999):
+    def parse(self, text: str, dt, pos: int = 0, debug=-9999):
         raise NotImplementedError
 
     def date_from(self, text, dt=None, pos=0, debug=-9999):
@@ -135,7 +135,7 @@ class Sequence(MultiBase):
             self.sep_expr = None
         self.progressive = progressive
 
-    def parse(self, text, dt, pos=0, debug=-9999):
+    def parse(self, text: str, dt, pos: int = 0, debug=-9999):
         d = adatetime()
         first = True
         foundall = False
@@ -230,7 +230,7 @@ class Combo(Sequence):
         self.min = min
         self.max = max
 
-    def parse(self, text, dt, pos=0, debug=-9999):
+    def parse(self, text: str, dt, pos: int = 0, debug=-9999):
         dates = []
         first = True
 
@@ -286,7 +286,7 @@ class Combo(Sequence):
 class Choice(MultiBase):
     """Returns the date from the first of its sub-elements that matches."""
 
-    def parse(self, text, dt, pos=0, debug=-9999):
+    def parse(self, text: str, dt, pos: int = 0, debug=-9999):
         print_debug(debug, "Choice %s text=%r", self.name, text[pos:])
         for e in self.elements:
             print_debug(debug, "Choice %s trying=%r", self.name, e)
@@ -338,7 +338,7 @@ class Bag(MultiBase):
         self.allof = allof
         self.anyof = anyof
 
-    def parse(self, text, dt, pos=0, debug=-9999):
+    def parse(self, text: str, dt, pos: int = 0, debug=-9999):
         first = True
         d = adatetime()
         seen = [False] * len(self.elements)
@@ -402,7 +402,7 @@ class Optional(ParserBase):
     def __repr__(self):
         return f"{self.__class__.__name__}({self.element!r})"
 
-    def parse(self, text, dt, pos=0, debug=-9999):
+    def parse(self, text: str, dt, pos: int = 0, debug=-9999):
         try:
             d, pos = self.element.parse(text, dt, pos, debug + 1)
         except TimeError:
@@ -425,7 +425,7 @@ class ToEnd(ParserBase):
     def __repr__(self):
         return f"{self.__class__.__name__}({self.element!r})"
 
-    def parse(self, text, dt, pos=0, debug=-9999):
+    def parse(self, text: str, dt, pos: int = 0, debug=-9999):
         try:
             d, pos = self.element.parse(text, dt, pos, debug + 1)
         except TimeError:
@@ -462,7 +462,7 @@ class Regex(ParserBase):
     def __repr__(self):
         return f"<{self.pattern!r}>"
 
-    def parse(self, text, dt, pos=0, debug=-9999):
+    def parse(self, text: str, dt, pos: int = 0, debug=-9999):
         m = self.expr.match(text, pos)
         if not m:
             return (None, None)
@@ -659,7 +659,7 @@ class DateParser:
     def get_parser(self):
         return self.all
 
-    def parse(self, text, dt, pos=0, debug=-9999):
+    def parse(self, text: str, dt, pos: int = 0, debug=-9999):
         parser = self.get_parser()
 
         d, newpos = parser.parse(text, dt, pos=pos, debug=debug)

--- a/src/whoosh/util/text.py
+++ b/src/whoosh/util/text.py
@@ -25,8 +25,12 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
+from __future__ import annotations
+
 import codecs
 import re
+from collections.abc import Iterable, Iterator, Sequence
+from typing import Any
 
 # Note: these functions return a tuple of (text, length), so when you call
 # them, you have to add [0] on the end, e.g. str = utf8encode(unicode)[0]
@@ -38,11 +42,11 @@ utf8decode = codecs.getdecoder("utf-8")
 # Prefix encoding functions
 
 
-def byte(num):
+def byte(num: int) -> bytes:
     return bytes((num,))
 
 
-def first_diff(a, b):
+def first_diff(a: Sequence[Any], b: Sequence[Any]) -> int:
     """
     Returns the position of the first differing character in the sequences a
     and b. For example, first_diff('render', 'rending') == 4. This function
@@ -56,17 +60,20 @@ def first_diff(a, b):
     return i
 
 
-def prefix_encode(a, b):
+def prefix_encode(a: str | bytes, b: str | bytes) -> bytes:
     """
     Compresses bytestring b as a byte representing the prefix it shares with a,
     followed by the suffix bytes.
     """
-
+    if isinstance(a, str):
+        a = a.encode("utf-8")
+    if isinstance(b, str):
+        b = b.encode("utf-8")
     i = first_diff(a, b)
     return byte(i) + b[i:]
 
 
-def prefix_encode_all(ls):
+def prefix_encode_all(ls: Iterable[str]) -> Iterator[bytes]:
     """Compresses the given list of (unicode) strings by storing each string
     (except the first one) as an integer (encoded in a byte) representing
     the prefix it shares with its predecessor, followed by the suffix encoded
@@ -76,16 +83,16 @@ def prefix_encode_all(ls):
     last = ""
     for w in ls:
         i = first_diff(last, w)
-        yield chr(i) + w[i:].encode("utf-8")
+        yield byte(i) + w[i:].encode("utf-8")
         last = w
 
 
-def prefix_decode_all(ls):
+def prefix_decode_all(ls: Iterable[bytes]) -> Iterator[str]:
     """Decompresses a list of strings compressed by prefix_encode()."""
 
     last = ""
     for w in ls:
-        i = ord(w[0])
+        i = ord(w[0]) if isinstance(w[0], str) else w[0]
         decoded = last[:i] + w[1:].decode("utf-8")
         yield decoded
         last = decoded
@@ -96,14 +103,14 @@ def prefix_decode_all(ls):
 _nkre = re.compile(r"\D+|\d+", re.UNICODE)
 
 
-def _nkconv(i):
+def _nkconv(i: str) -> int | str:
     try:
         return int(i)
     except ValueError:
         return i.lower()
 
 
-def natural_key(s):
+def natural_key(s: str) -> tuple[int | str, ...]:
     """Converts string ``s`` into a tuple that will sort "naturally" (i.e.,
     ``name5`` will come before ``name10`` and ``1`` will come before ``A``).
     This function is designed to be used as the ``key`` argument to sorting
@@ -122,7 +129,9 @@ def natural_key(s):
 # Regular expression functions
 
 
-def rcompile(pattern, flags=0, verbose=False):
+def rcompile(
+    pattern: str | re.Pattern[Any], flags: int = 0, verbose: bool = False
+) -> re.Pattern[Any]:
     """A wrapper for re.compile that checks whether "pattern" is a regex object
     or a string to be compiled, and automatically adds the re.UNICODE flag.
     """

--- a/src/whoosh/util/text.py
+++ b/src/whoosh/util/text.py
@@ -130,8 +130,8 @@ def natural_key(s: str) -> tuple[int | str, ...]:
 
 
 def rcompile(
-    pattern: str | re.Pattern[Any], flags: int = 0, verbose: bool = False
-) -> re.Pattern[Any]:
+    pattern: str | re.Pattern[str], flags: int = 0, verbose: bool = False
+) -> re.Pattern[str]:
     """A wrapper for re.compile that checks whether "pattern" is a regex object
     or a string to be compiled, and automatically adds the re.UNICODE flag.
     """


### PR DESCRIPTION
Fixes #173 (part of #121)

Adds parameter and return type annotations to all public functions in \src/whoosh/util/text.py\:
- \yte(num: int) -> bytes\
- \irst_diff(a: Sequence[Any], b: Sequence[Any]) -> int\
- \prefix_encode(a: str | bytes, b: str | bytes) -> bytes\
- \prefix_encode_all(ls: Iterable[str]) -> Iterator[bytes]\
- \prefix_decode_all(ls: Iterable[bytes]) -> Iterator[str]\
- \
atural_key(s: str) -> tuple[int | str, ...]\
- \compile(pattern: str | re.Pattern[Any], flags: int = 0, verbose: bool = False) -> re.Pattern[Any]\
- Internal \_nkconv(i: str) -> int | str\

Also includes \rom __future__ import annotations\, defensive coercions in prefix encoding helpers, and records the change under \## [Unreleased]\ in \CHANGELOG.md\.

All local checks pass:
- \	y check src/whoosh/util/text.py\
- \uff check src/whoosh/util/text.py\
- \uff format --check src/whoosh/util/text.py\
- \pytest tests/test_sorting.py -q\ (37/37 passed)