### PR TITLE
fix(matching): CoordMatcher no longer zeroes single-term query scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- `CoordMatcher` (used by `OrGroup.factory(scale)`) no longer scores every hit
+  `0.0` when a query resolves to a single term matcher. The SQR coordination
+  factor `(termcount - 1) / termcount` collapses to `0` for a single term —
+  the common case for a single-word query over a `MultifieldParser`, where the
+  term survives in only one field — which zeroed all scores and left ranking in
+  arbitrary docnum order. A single-term query now returns the unmodified score
+  (there is nothing to coordinate over); genuine multi-term coordination
+  penalties are unchanged. Thanks to @bet0x for the detailed root-cause report.
+
 ### Changed
 
 - Typing: added parameter and return annotations to all public functions in

--- a/src/whoosh/matching/wrappers.py
+++ b/src/whoosh/matching/wrappers.py
@@ -547,8 +547,19 @@ class CoordMatcher(WrappingMatcher):
         scale = self._scale  # Scaling factor
 
         # Gracefully handle no terms
-        if termcount == 0 or termcount == scale:
+        if termcount == 0:
             return 0
+
+        # A coordination penalty only makes sense when there is more than one
+        # term to coordinate over. With a single term the trailing
+        # ``(termcount - 1) / termcount`` factor collapses to 0 and zeroes the
+        # score of *every* hit -- a common surprise for single-word queries
+        # over a MultifieldParser, where the term survives in only one field.
+        # It also divides by zero when ``termcount == scale`` (the default
+        # scale of 1.0 with a single term). In either case there is nothing to
+        # penalize, so return the unmodified score.
+        if termcount <= 1 or termcount == scale:
+            return score
 
         sqr = (score + ((matching - 1) / (termcount - scale) ** 2)) * (
             (termcount - 1) / termcount

--- a/tests/test_searching.py
+++ b/tests/test_searching.py
@@ -1674,6 +1674,38 @@ def test_coord():
         assert [hit["id"] for hit in r] == [4, 5, 3, 6, 1, 8, 2, 7]
 
 
+def test_coord_single_term():
+    # A CoordMatcher (OrGroup.factory) must not zero the score of every hit
+    # when the query resolves to a single term matcher -- e.g. a single-word
+    # query over a MultifieldParser where the term survives in only one field.
+    # Regression: the SQR (termcount - 1) / termcount factor collapsed to 0.
+    schema = fields.Schema(
+        heading=fields.TEXT(stored=True), body=fields.TEXT(stored=True)
+    )
+    ix = RamStorage().create_index(schema)
+    with ix.writer() as w:
+        w.add_document(heading="Pods", body="rollout restart the deployment")
+        w.add_document(heading="Plain", body="rollout notes here")
+
+    og = qparser.OrGroup.factory(0.9)
+    qp = qparser.MultifieldParser(["heading", "body"], schema, group=og)
+    q = qp.parse("rollout")
+
+    with ix.searcher() as s:
+        r = s.search(q)
+        assert len(r) == 2
+        # Every hit must be scoreable, not zeroed.
+        assert all(hit.score > 0 for hit in r)
+
+    # A genuine multi-term coordination penalty must still apply: a document
+    # matching both terms should outrank one matching only one term.
+    q2 = qp.parse("rollout restart")
+    with ix.searcher() as s:
+        r = s.search(q2)
+        scores = {hit["heading"]: hit.score for hit in r}
+        assert scores["Pods"] > scores["Plain"]
+
+
 def test_keyword_search():
     schema = fields.Schema(tags=fields.KEYWORD)
     ix = RamStorage().create_index(schema)


### PR DESCRIPTION
## Problem

`OrGroup.factory(scale)` wraps the `Or` in `CoordMatcher`, whose SQR coordination factor is:

```python
sqr = (score + ((matching - 1) / (termcount - scale) ** 2)) * ((termcount - 1) / termcount)
```

When a query resolves to a **single** live term matcher, `(termcount - 1) / termcount = (1 - 1) / 1 = 0`, so **every** hit scores exactly `0.0` and ranking falls back to arbitrary docnum order. This is the common case for a single-word query over a `MultifieldParser`: the term matches in one field (e.g. `body`) and not another (e.g. `heading`), leaving one `NullMatcher`.

The default `scale` of `1.0` with a single term also hits the `termcount == scale` guard, which previously returned `0` — masking the same zeroing.

### Reproduction (before)

```
factory(0.9)  rollout ->  [('Pods', 0.0), ('Plain', 0.0)]
plain OrGroup rollout ->  [('Pods', 0.595), ('Plain', 0.595)]
```

## Fix

A single-term query has nothing to coordinate over, so return the **unmodified score**. Genuine multi-term coordination penalties are unchanged.

### After

```
factory(0.9)  rollout ->          [('Pods', 0.595), ('Plain', 0.595)]
factory(0.9)  rollout restart ->  [('Pods', 1.21),  ('Plain', 0.297)]   # penalty still applies
```

## Tests

- Existing `test_coord` still passes (multi-term penalty unchanged).
- New `test_coord_single_term` asserts single-term hits are scoreable **and** that a genuine multi-term coordination penalty still ranks a two-term match above a one-term match.
- Full `tests/test_searching.py` + `tests/test_matching.py` green.

## Credit

Root cause was traced in precise detail by **@bet0x** (in a downstream project that inherits this code from Whoosh). Fixing it here in the maintained fork so the upstream bug doesn't propagate further.