### PR TITLE
release: 3.49.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+## [3.49.8] - 2026-09-04
+
 ### Fixed
 
 - `CoordMatcher` (used by `OrGroup.factory(scale)`) no longer scores every hit

--- a/demo/index.html
+++ b/demo/index.html
@@ -32,7 +32,7 @@
   "url": "https://priya-sundaram-dev.github.io/whoosh/",
   "downloadUrl": "https://pypi.org/project/whoosh3/",
   "codeRepository": "https://github.com/priya-sundaram-dev/whoosh",
-  "softwareVersion": "3.49.7",
+  "softwareVersion": "3.49.8",
   "license": "https://github.com/priya-sundaram-dev/whoosh/blob/main/LICENSE.txt",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
   "keywords": "full-text search, pure python search, BM25, indexing, information retrieval, whoosh, Flask search, Django search, SQLite FTS alternative",

--- a/demo/is-whoosh-still-maintained.html
+++ b/demo/is-whoosh-still-maintained.html
@@ -148,7 +148,7 @@
       existing on-disk indexes keep working;</li>
     <li>ships tagged releases to PyPI with a
       <a href="https://github.com/priya-sundaram-dev/whoosh/blob/main/CHANGELOG.md">changelog</a>
-      &mdash; the latest is <strong>whoosh3&nbsp;3.49.7</strong> (September&nbsp;2026),
+      &mdash; the latest is <strong>whoosh3&nbsp;3.49.8</strong> (September&nbsp;2026),
       one of a steady run of bug-fix and feature releases shipped this month;</li>
     <li>has a public issue tracker with labeled
       <a href="https://github.com/priya-sundaram-dev/whoosh/issues">good-first-issues</a>

--- a/src/whoosh/__init__.py
+++ b/src/whoosh/__init__.py
@@ -25,7 +25,7 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
-__version__: tuple[int, ...] = (3, 49, 7)
+__version__: tuple[int, ...] = (3, 49, 8)
 #: String form of :data:`__version__`, kept in sync automatically so the two
 #: can never drift. Used as the single source of truth for the packaged version
 #: (see ``pyproject.toml``'s ``version = { attr = "whoosh.__version_str__" }``).


### PR DESCRIPTION
Patch release cutting the merged `CoordMatcher` single-term scoring fix (#181, thanks @bet0x) plus the accumulated `util.text`/`util.varints` typing work.

## Changes
- **Fixed:** `CoordMatcher` (`OrGroup.factory(scale)`) no longer zeroes every score when a query resolves to a single term matcher — the common single-word `MultifieldParser` case. Single-term queries return the unmodified score; multi-term coordination penalties unchanged.
- **Changed:** parameter/return annotations for all public functions in `whoosh.util.text` (gh#173) and `whoosh.util.varints` (gh#178), part of gh#121.

## Release mechanics
- Bumped `__version__` → `(3, 49, 8)`
- Moved `[Unreleased]` block under `## [3.49.8] - 2026-09-04`
- Refreshed `softwareVersion` in demo JSON-LD + the "latest release" line in the maintained-status page

Publishing to PyPI (whoosh3) happens automatically via Trusted Publishing when the GitHub Release is created after this merges.