### PR TITLE
Add type hints to whoosh.util.loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project follows
 
 ## [Unreleased]
 
+### Changed
+
+- Added type hints to `whoosh.util.loading` (#180).
+
 ## [3.49.8] - 2026-09-04
 
 ### Fixed

--- a/src/whoosh/util/loading.py
+++ b/src/whoosh/util/loading.py
@@ -25,7 +25,11 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
+from __future__ import annotations
+
 import pickle
+from collections.abc import Iterable
+from typing import IO, Any
 
 
 class RenamingUnpickler(pickle.Unpickler):
@@ -33,14 +37,19 @@ class RenamingUnpickler(pickle.Unpickler):
     loading them.
     """
 
-    def __init__(self, f, objmap, shortcuts=None):
+    def __init__(
+        self,
+        f: IO[bytes],
+        objmap: dict[str, str],
+        shortcuts: dict[str, str] | None = None,
+    ) -> None:
         pickle.Unpickler.__init__(self, f)
 
         if shortcuts:
             objmap = {k % shortcuts: v % shortcuts for k, v in objmap.items()}
         self._objmap = objmap
 
-    def find_class(self, modulename, objname):
+    def find_class(self, modulename: str, objname: str) -> Any:
         fqname = f"{modulename}.{objname}"
         if fqname in self._objmap:
             fqname = self._objmap[fqname]
@@ -51,7 +60,11 @@ class RenamingUnpickler(pickle.Unpickler):
         return obj
 
 
-def find_object(name, blacklist=None, whitelist=None):
+def find_object(
+    name: str,
+    blacklist: Iterable[str] | None = None,
+    whitelist: Iterable[str] | None = None,
+) -> Any:
     """Imports and returns an object given a fully qualified name.
 
     >>> find_object("whoosh.analysis.StopFilter")


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

Adds type annotations to `whoosh.util.loading` without changing runtime behavior.

## Related issues

Closes https://github.com/priya-sundaram-dev/whoosh/issues/180

## Checklist

- [X] Tests pass locally (`pytest tests/`)
- [ ] Added/updated tests for the change where it makes sense
- [X] Updated docs / CHANGELOG if user-facing
- [X] I have read the [CONTRIBUTING](https://github.com/priya-sundaram-dev/whoosh/blob/main/CONTRIBUTING.md) guide