### PR TITLE
Annotate numlists encoder and decoder callables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ warn_unused_ignores = true
 # None in __init__ then reassigned.  Clearing those means broad annotation work or
 # per-line ignores rather than quick fixes; `invalid-ignore-comment` (cleared in
 # gh#144) and the empty-body/parameter-already-assigned rules were the easy wins.
-rules.call-non-callable = "ignore"  # 18 instances (remaining are None/object/str unions, not the analysis pipeline)
+rules.call-non-callable = "ignore"  # 15 instances (remaining are None/object/str unions, not the analysis pipeline)
 rules.invalid-argument-type = "ignore"  # 39 instances
 rules.invalid-assignment = "ignore"  # 26 instances
 rules.invalid-method-override = "ignore"  # 139 instances

--- a/src/whoosh/util/numlists.py
+++ b/src/whoosh/util/numlists.py
@@ -1,4 +1,5 @@
 from array import array
+from collections.abc import Callable
 
 from whoosh.system import (
     emptybytes,
@@ -114,8 +115,8 @@ class NumberEncoding:
 
 
 class FixedEncoding(NumberEncoding):
-    _encode = None
-    _decode = None
+    _encode: Callable[[int], bytes]
+    _decode: Callable[[bytes], tuple[int]]
     size = None
 
     def write_nums(self, f, numbers):


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

Adds explicit `Callable` annotations for the encoder and decoder attributes in `whoosh.util.numlists`.

This removes the three `call-non-callable` findings in `numlists.py` without changing runtime behavior.

## Related issues

Refs #121

## Checklist

- [X] Tests pass locally (`pytest tests/`)
- [ ] Added/updated tests for the change where it makes sense
- [X] Updated docs / CHANGELOG if user-facing
- [X] I have read the [CONTRIBUTING](https://github.com/priya-sundaram-dev/whoosh/blob/main/CONTRIBUTING.md) guide