### PR TITLE
types: narrow optional parent weakref before calling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ warn_unused_ignores = true
 # None in __init__ then reassigned.  Clearing those means broad annotation work or
 # per-line ignores rather than quick fixes; `invalid-ignore-comment` (cleared in
 # gh#144) and the empty-body/parameter-already-assigned rules were the easy wins.
-rules.call-non-callable = "ignore"  # 15 instances (remaining are None/object/str unions, not the analysis pipeline)
+rules.call-non-callable = "ignore"  # 14 instances (remaining are None/object/str unions, not the analysis pipeline)
 rules.invalid-argument-type = "ignore"  # 39 instances
 rules.invalid-assignment = "ignore"  # 26 instances
 rules.invalid-method-override = "ignore"  # 139 instances

--- a/src/whoosh/searching.py
+++ b/src/whoosh/searching.py
@@ -208,11 +208,11 @@ class Searcher:
         return self.parent is not None
 
     def get_parent(self):
-        """Returns the parent of this searcher (if has_parent() is True), or
+        """Returns the parent of this searcher (if self.parent is not None), or
         else self.
         """
 
-        if self.has_parent():
+        if self.parent is not None:
             # Call the weak reference to get the parent searcher
             return self.parent()
         else:


### PR DESCRIPTION
<!-- Thanks for contributing to Whoosh! -->

## Summary

- Replace the indirect `has_parent()` check in `Searcher.get_parent()` with a direct `self.parent is not None` guard.

`ty check src/whoosh/searching.py` passes after this change.

## Related issues

Related to #121.

## Checklist

- [X] Tests pass locally (`pytest tests/`)
- [ ] Added/updated tests for the change where it makes sense
- [X] Updated docs / CHANGELOG if user-facing
- [X] I have read the [CONTRIBUTING](https://github.com/priya-sundaram-dev/whoosh/blob/main/CONTRIBUTING.md) guide
